### PR TITLE
Fix API including input tokens in generated output

### DIFF
--- a/src/engine/optimum_inference_core.py
+++ b/src/engine/optimum_inference_core.py
@@ -262,11 +262,14 @@ class Optimum_InferenceCore:
                 eos_token_id=generation_config.eos_token_id,
             )
 
-            # Generate text
+            # Generate outpus from the model
             outputs = self.model.generate(**generation_kwargs)
             
+            # Extract new tokens by excluding the input tokens
+            new_tokens = outputs[0][input_ids.shape[1]:]
+            
             # Decode the generated tokens
-            generated_text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            generated_text = self.tokenizer.decode(new_tokens, skip_special_tokens=True)
             
             # Stop generation timer
             self.performance_metrics.stop_generation_timer()

--- a/src/engine/optimum_inference_core.py
+++ b/src/engine/optimum_inference_core.py
@@ -86,7 +86,7 @@ class Optimum_PerformanceMetrics:
             self.performance_config.output_tokens = output_tokens
             
             # Calculate new tokens
-            self.performance_config.new_tokens = output_tokens - input_tokens
+            self.performance_config.new_tokens = output_tokens
             
         except Exception as e:
             print(f"Error counting tokens: {str(e)}")


### PR DESCRIPTION
Fixes:

1. Separate input/output tokens explicitly slicing generated outputs to exclude input tokens
 - (outputs[0][input_ids.shape[1]:]), ensuring only new tokens are decoded and returned.

2. Align output token counting:
 - Removes output_tokens - input_tokens logic since outputs no longer contain inputs.