### PR TITLE
Fix streaming issues with chat template

### DIFF
--- a/src/engine/optimum_inference_core.py
+++ b/src/engine/optimum_inference_core.py
@@ -165,7 +165,7 @@ class Optimum_InferenceCore:
         self.tokenizer = AutoTokenizer.from_pretrained(self.load_model_config.id_model)
         print("Tokenizer loaded successfully.")
 
-    async def generate_stream(self, generation_config: OV_GenerationConfig) -> AsyncIterator[str]: # TODO: Something here breaks the chat template but still does streaming
+    async def generate_stream(self, generation_config: OV_GenerationConfig) -> AsyncIterator[str]:
         """
         Asynchronously stream generated text tokens.
         
@@ -181,12 +181,12 @@ class Optimum_InferenceCore:
             input_ids = self.tokenizer.apply_chat_template(
                 generation_config.conversation,
                 tokenize=True,
-                add_generation_prompt=False,
+                add_generation_prompt=True,
                 return_tensors="pt"
             )
 
             # Initialize the streamer with tokenized input
-            streamer = TextIteratorStreamer(self.tokenizer)
+            streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)
 
             # Create generation kwargs from config
             generation_kwargs = dict(


### PR DESCRIPTION
Fixed the tokenizer config for stream to prevent it from returning the entire context.

Changed `add_generation_prompt=False` to `True` and added `skip_prompt=True, skip_special_tokens=True` to the TextIteratorStreamer config.

**Before:**
bash streamit.sh 
`<s>[INST]Write a short story about a giraffe.[/INST]In the heart of the African savannah, there lived a giraffe named Gerald. Gerald was not like the other giraffes. He was shorter and his spots were slightly faded, but he had a heart full of curiosity and kindness.`

**After:**
bash streamit.sh 
`In the heart of the African savannah, there lived a tall, lanky giraffe named Gerald. Gerald was not like the other giraffes. He had a unique spot pattern that resembled a constellation, which the other animals often admired. However, Gerald felt different and often wondered if he truly belonged.`
