### PR TITLE
Openai v1/model and v1/chat/completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python bytecode and cache files
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+*.egg
+.pytest_cache/
+.mypy_cache/

--- a/src/api/optimum_api.py
+++ b/src/api/optimum_api.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from typing import Optional, AsyncIterator
+from datetime import datetime
 
 from engine.optimum_inference_core import (
     OV_LoadModelConfig,
@@ -86,4 +87,24 @@ async def get_status():
         "status": "loaded",
         "id_model": model_instance.load_model_config.id_model,
         "device": model_instance.load_model_config.device
+    }
+
+@app.get("/v1/models")
+async def get_models():
+    """Get list of available models in openai format"""
+    global model_instance
+    data = []
+    
+    if model_instance:
+        model_data = {
+            "id": model_instance.load_model_config.id_model,
+            "object": "model",
+            "created": int(datetime.utcnow().timestamp()),
+            "owned_by": "OpenArc",  # Our platform identifier a placeholder
+        }
+        data.append(model_data)
+    
+    return {
+        "object": "list",
+        "data": data
     }

--- a/src/api/optimum_api.py
+++ b/src/api/optimum_api.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
-from typing import Optional, AsyncIterator
+from fastapi.responses import StreamingResponse, JSONResponse
+from typing import Optional, AsyncIterator, List, Dict, Any
+from pydantic import BaseModel, Extra
 from datetime import datetime
+import logging
+import time
+import uuid
+import json
 
 from engine.optimum_inference_core import (
     OV_LoadModelConfig,
@@ -15,6 +20,18 @@ app = FastAPI(title="OpenVINO Inference API")
 # Global state to store model instance
 model_instance: Optional[Optimum_InferenceCore] = None
 
+# OpenAI-compatible request models
+class ChatCompletionRequest(BaseModel):
+    messages: List[Dict[str, str]]
+    model: str = "default"
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    stream: Optional[bool] = False
+    stop: Optional[List[str]] = None
+
+    class Config:
+        extra = Extra.ignore
+        
 @app.post("/model/load")
 async def load_model(load_config: OV_LoadModelConfig, ov_config: OV_Config):
     """Load a model with the specified configuration"""

--- a/src/api/optimum_api.py
+++ b/src/api/optimum_api.py
@@ -125,3 +125,76 @@ async def get_models():
         "object": "list",
         "data": data
     }
+
+@app.post("/v1/chat/completions")
+async def openai_chat_completions(request: ChatCompletionRequest):
+    global model_instance
+    if not model_instance:
+        raise HTTPException(status_code=503, detail="No model loaded")
+    
+    # Toggle debug output here
+    DEBUG = True
+    if DEBUG:
+        print("\n=== Received Request ===")
+        print("Raw messages:", request.messages)
+        print("Params - temperature:", request.temperature)
+        print("Params - max_tokens:", request.max_tokens)
+
+    try:
+        # Convert OpenAI-style messages to conversation format
+        conversation = [
+            {"role": msg["role"], "content": msg["content"]}
+            for msg in request.messages
+        ]
+        
+        if DEBUG:
+            print("Processed conversation:", conversation)
+
+        # Create generation config with conversation structure
+        generation_config = OV_GenerationConfig(
+            conversation=conversation,  # This matches the original working format
+            temperature=request.temperature or 0.7,
+            max_new_tokens=request.max_tokens or 512, # Handles both max_tokens and max_new_tokens via alias
+            stop_sequences=request.stop or [],
+            repetition_penalty=1.0,
+            do_sample=True,
+            num_return_sequences=1
+        )
+        
+        if request.stream:
+            async def stream_generator():
+                try:
+                    async for token in model_instance.generate_stream(generation_config):
+                        # Properly escape the content for JSON, preserving all whitespace
+                        escaped_token = json.dumps(token)[1:-1]  # Remove surrounding quotes
+                        yield f"data: {{\"object\": \"chat.completion.chunk\", \"choices\": [{{\"delta\": {{\"content\": \"{escaped_token}\"}}}}]}}\n\n"
+                        
+                except Exception as e:
+                    print(f"Error during streaming: {str(e)}")
+                finally:
+                    yield "data: [DONE]\n\n"
+                    
+                    
+            return StreamingResponse(stream_generator(), media_type="text/event-stream")
+        
+        else:
+            generated_text, metrics = model_instance.generate_text(generation_config)
+            print(metrics)
+            return JSONResponse(content={
+                "id": f"ov-{uuid.uuid4()}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model_instance.load_model_config.id_model,
+                "choices": [{
+                    "message": {"role": "assistant", "content": generated_text},
+                    "finish_reason": "length"
+                }],
+                "timings": {
+                    "prompt_tokens": metrics.get("input_tokens", 0),
+                    "completion_tokens": metrics.get("output_tokens", 0),
+                    "total_tokens": metrics.get("input_tokens", 0) + metrics.get("output_tokens", 0)
+                }
+            })
+    
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/start_optimum_api.py
+++ b/src/start_optimum_api.py
@@ -24,8 +24,10 @@ def start_server(host: str = "0.0.0.0", port: int = 8000, reload: bool = False):
     logger.info("  - DELETE /model/unload    Unload current model")
     logger.info("  - POST   /generate/text   Generate text synchronously")
     logger.info("  - POST   /generate/stream Stream text generation")
-    logger.info("  - GET    /status         Get model status")
-    logger.info("  - GET    /docs           API documentation")
+    logger.info("  - GET    /status          Get model status")
+    logger.info("  - GET    /docs            API documentation")
+    logger.info("  - POST   /v1/chat         Openai chat completions")
+    logger.info("  - GET    /v1/models       Get model list")
     
     # Start the server
     uvicorn.run(


### PR DESCRIPTION
Here's an initial implementation of openai chat completions, enough to work with open-webui and SillyTavern.

**v1/models**
- GET method to list available models.
- This is required for open-webui to connect.
- I based this implementation off the llama.cpp llama-server. 

**v1/chat/completions**
- Supports stream=true or stream=false
- Required changes to the inference engine core to load special tokens from the model configuration file.
-- tested compatibly with the existing text streaming and text generation APIs (note: master branch)

**git ignore**
Created .gitignore and added the bytecode/cache files.