### PR TITLE
fix(api): Add missing output_tokens field to OV_PerformanceConfig

### DIFF
--- a/src/engine/optimum/optimum_inference_core.py
+++ b/src/engine/optimum/optimum_inference_core.py
@@ -55,6 +55,7 @@ class OV_GenerationConfig(BaseModel):
 class OV_PerformanceConfig(BaseModel):
     generation_time: Optional[float] = Field(None, description="Generation time in seconds")
     input_tokens: Optional[int] = Field(None, description="Number of input tokens")
+    output_tokens: Optional[int] = Field(None, description="Number of output tokens")
     new_tokens: Optional[int] = Field(None, description="Number of new tokens generated")
     eval_time: Optional[float] = Field(None, description="Evaluation time in seconds")
 


### PR DESCRIPTION
Fixed an attribute error in the OpenAI-compatible chat completions endpoint where the OV_PerformanceConfig Pydantic model was missing the 'output_tokens' field. This field is used for tracking token counts during inference and is required by the metrics reporting functions.

- Added output_tokens field to the OV_PerformanceConfig class with proper type and description

This resolves the 500 error when using non-streaming API responses