### PR TITLE
Openai v1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyo
 *.pyd
 *.so
+*.pyc
 *.egg-info/
 *.egg
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -145,11 +145,7 @@ Feel free to use the Discord for this as well but be prepared to document your s
 
 ### Ubuntu
 
-Make it executable
-
-	sudo chmod +x environment.yaml
- 
-Then create the conda environment
+Create the conda environment:
 
 	conda env create -f environment.yaml
 


### PR DESCRIPTION
# API Enhancements and Documentation Improvements

This PR contains several improvements:

## Feature Additions
1. **OpenAI Text Completions Endpoint** 
   - Access via /v1/completions
   - Useful for fine-grained control over the chat template
   - Allows few-shot prompting of base models

2. **Stream Performance Metrics** (for evaluation purposes)
   - Measures prompt evaluation time (time to first token)
   - Calculates tokens per second for both prompt evaluation and response generation
   - Displays metrics in console when DEBUG is enabled
   - Note: This is a minimal implementation that can be cherry-picked if desired

## Maintenance Updates
1. **Fix incorrect instructions in README.md**
   - Remove instructions to make YAML files executable - this is unnecessary as YAML files are configuration files read by conda, not scripts that need execution permission

2. **Update .gitignore to include Python bytecode files**
   - Add Python bytecode files (`.pyc`) to .gitignore to prevent accidentally committing generated files

The feature additions can be cherry-picked individually if you prefer to evaluate them separately.