### PR TITLE
Add /tokenize and /apply-template endpoints like llama.cpp offers. 

### DIFF
--- a/src/cli/launch_server.py
+++ b/src/cli/launch_server.py
@@ -96,6 +96,8 @@ def start_server(host: str = "0.0.0.0", openarc_port: int = 8001, reload: bool =
     logger.info("  - POST   /v1/audio/speech: Kokoro only")
     logger.info("  - POST   /v1/embeddings")
     logger.info("  - POST   /v1/rerank")
+    logger.info("  - POST   /v1/apply-template: llama.cpp compatible")
+    logger.info("  - POST   /v1/tokenize: llama.cpp compatible")
     
 
     uvicorn.run(


### PR DESCRIPTION
I wanted to understand the performance OpenArc offers and wanted to run server-benchmark.py from llama.cpp for benchmarking. It relies on retrieving the prompt template of a model via the API, and to then tokenize this prompt plus user query with a output token cut-off so that we get a fixed amount of input tokens.

I've added these two endpoints in both the API endpoint that llama.cpp offers and also the OpenAI API compatible endpoint with /v1/ prefix. This aids in running benchmarks and getting compatibility up with llama-server, and I assume that also other uses can be found (especially retrieving the system prompt sounds handy for front-ends).

Would you consider merging these?