### PR TITLE
Update Dockerfile to use libze-intel-gpu1 instead of level-zero for GPU dependencies.

### DIFF
--- a/Battlemage.Dockerfile
+++ b/Battlemage.Dockerfile
@@ -1,5 +1,6 @@
 # ============================================================================
 # OpenARC From Scratch - Ubuntu Base + Manual Intel Setup
+# NOTE: For Battlemage or newer GPUs
 # ============================================================================
 FROM ubuntu:24.04
 

--- a/Battlemage.Dockerfile
+++ b/Battlemage.Dockerfile
@@ -9,6 +9,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # System Dependencies
 # ============================================================================
 RUN apt-get update && apt-get install -y \
+    software-properties-common
+RUN add-apt-repository ppa:kobuk-team/intel-graphics
+
+RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     git \
@@ -30,10 +34,8 @@ RUN wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble client" | \
     tee /etc/apt/sources.list.d/intel-gpu-noble.list && \
     apt-get update && apt-get install -y \
-    intel-opencl-icd \
-    intel-level-zero-gpu \
-    level-zero \
-    level-zero-dev && \
+    libze-intel-gpu1 \
+    intel-opencl-icd && \
     rm -rf /var/lib/apt/lists/*
 
 # ============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # System Dependencies
 # ============================================================================
 RUN apt-get update && apt-get install -y \
+    software-properties-common
+RUN add-apt-repository ppa:kobuk-team/intel-graphics
+
+RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     git \
@@ -30,10 +34,8 @@ RUN wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble client" | \
     tee /etc/apt/sources.list.d/intel-gpu-noble.list && \
     apt-get update && apt-get install -y \
-    intel-opencl-icd \
-    intel-level-zero-gpu \
-    level-zero \
-    level-zero-dev && \
+    libze-intel-gpu1 \
+    intel-opencl-icd && \
     rm -rf /var/lib/apt/lists/*
 
 # ============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # ============================================================================
 # OpenARC From Scratch - Ubuntu Base + Manual Intel Setup
+# NOTE: 
+#       Newer GPUs require using the `libze` packages instead of `level-zero`.
+#       For Battlemage or newer, you should use `Battlemage.Dockerfile` instead.
 # ============================================================================
 FROM ubuntu:24.04
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ docker-compose up --build -d
 ```
 
 
-Take a look at the [Dockerfile](Dockerfile) and [docker-compose](docker-compose.yaml) for more details.
+Take a look at the [docker-compose](docker-compose.yaml) and [Dockerfile](Dockerfile) ([Battlemage Dockerfile](Battlemage.Dockerfile)) for more details.
 
 </details>
 


### PR DESCRIPTION
This PR adds Docker support for Battlemage GPUs by replacing `intel-level-zero-gpu`, `level-zero`, and `level-zero-dev` with `libze-intel-gpu1`. As these are only present in the Intel kobuk PPA, I have also added that as a apt repository.

I've only tested this on a B60 Pro and cannot confirm if it works for older GPUs. If this doesn't work for them, I can resubmit this PR using a separate Dockerfile for Battlemage. 