### PR TITLE
Docs (serve): Windows 127.0.0.1 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ uv pip install --pre -U openvino-genai --extra-index-url https://storage.openvin
 setx OPENARC_API_KEY openarc-api-key
 ```
 
-5.1 Or specify a variable in each CMD window:
+Or specify a variable in each CMD window:
 ```
 set OPENARC_API_KEY=234 # example
 ```

--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ uv pip install --pre -U openvino-genai --extra-index-url https://storage.openvin
 setx OPENARC_API_KEY openarc-api-key
 ```
 
+5.1 Or specify a variable in each CMD window:
+```
+set OPENARC_API_KEY=234 # example
+```
+
 6. To get started, run:
 
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -408,6 +408,12 @@ This page contains example commands to help you choose models and configure Open
     ```
     openarc serve start # defaults to 0.0.0.0:8000
     ```
+    Windows 11:
+
+    To exclude _Request failed_ in Windows, you need to specify this address
+    ```
+    openarc serve start --host 127.0.0.1
+    ```
 
     Configure host and port:
 


### PR DESCRIPTION
Added Windows-specific documentation for `openarc serve start`:

- `--host 127.0.0.1` required on Windows to avoid "Request failed" 
- Document default `0.0.0.0:8000` behavior works on Linux/macOS

Fixes Windows networking issues when binding to default `0.0.0.0`.

Error:
```
openarc status
Getting model status...
Request failed: HTTPConnectionPool(host='0.0.0.0', port=8000): Max retries exceeded with url: /openarc/status (Caused by
NewConnectionError('<urllib3.connection.HTTPConnection object at 0x0000020F09B46570>: Failed to establish a new
connection: [WinError 10049] The requested address is not valid in its context'))
```