### PR TITLE
- optimum_vlm backend

### DIFF
--- a/src/cli/groups/add.py
+++ b/src/cli/groups/add.py
@@ -24,10 +24,10 @@ from ..utils import validate_model_path
     type=click.Choice([
         'llm', 'vlm', 'whisper', 'qwen3_asr', 'kokoro',
         'qwen3_tts_custom_voice', 'qwen3_tts_voice_design', 'qwen3_tts_voice_clone',
-        'emb', 'rerank',
+        'emb', 'rerank', 'optimum_vlm',
     ]),
     required=True,
-    help='Model type (llm, vlm, whisper, qwen3_asr, kokoro, qwen3_tts_custom_voice, qwen3_tts_voice_design, qwen3_tts_voice_clone, emb, rerank)')
+    help='Model type (llm, vlm, whisper, qwen3_asr, kokoro, qwen3_tts_custom_voice, qwen3_tts_voice_design, qwen3_tts_voice_clone, emb, rerank, optimum_vlm)')
 @click.option('--device', '--d',
     required=True,
     help='Device(s) to load the model on.')

--- a/src/engine/optimum/optimum_vlm.py
+++ b/src/engine/optimum/optimum_vlm.py
@@ -1,20 +1,20 @@
 
 
+import gc
 import logging
+from transformers import AutoProcessor
+from optimum.intel.openvino import OVModelForVisualCausalLM
 
-from transformers import AutoTokenizer
-from optimum.intel.openvino import OVModelForCausalLM
-
-from src2.server.model_registry import ModelLoadConfig
-
-
-
-
+from src.server.model_registry import ModelRegistry
+from src.server.models.registration import ModelLoadConfig
 
 
 class Optimum_VLM:
     def __init__(self, load_config: ModelLoadConfig):
-        pass
+        self.load_config = load_config
+        self.model = None
+        self.tokenizer = None
+
     def generate_type():
         pass
 
@@ -30,8 +30,42 @@ class Optimum_VLM:
     def collect_metrics():
         pass
 
-    def load_model():
-        pass
+    def load_model(self, loader: ModelLoadConfig):
+        """Load model using a ModelLoadConfig configuration and cache the tokenizer.
 
-    async def unload_model():
-        pass
+        Args:
+            loader: ModelLoadConfig containing model_path, device, engine, and runtime_config.
+        """
+
+        self.model = OVModelForVisualCausalLM.from_pretrained(
+            loader.model_path,
+            device=loader.device,
+            export=False,
+        )
+
+        self.tokenizer = AutoProcessor.from_pretrained(loader.model_path)
+        logging.info(f"Model loaded successfully: {loader.model_name}")
+
+    async def unload_model(self, registry: ModelRegistry, model_name: str) -> bool:
+        """Unregister model from registry and free memory resources.
+
+        Args:
+            registry: ModelRegistry to unregister from
+            model_id: Private model identifier returned by register_load
+
+        Returns:
+            True if the model was found and unregistered, else False.
+        """
+        removed = await registry.register_unload(model_name)
+
+        if self.model is not None:
+            del self.model
+            self.model = None
+
+        if self.tokenizer is not None:
+            del self.tokenizer
+            self.tokenizer = None
+
+        gc.collect()
+        logging.info(f"[{self.load_config.model_name}] weights and tokenizer unloaded and memory cleaned up")
+        return removed

--- a/src/server/model_registry.py
+++ b/src/server/model_registry.py
@@ -232,6 +232,7 @@ MODEL_CLASS_REGISTRY = {
     (EngineType.OPENVINO, ModelType.QWEN3_TTS_VOICE_CLONE): "src.engine.openvino.qwen3_tts.qwen3_tts.OVQwen3TTS",
     (EngineType.OV_OPTIMUM, ModelType.EMB): "src.engine.optimum.optimum_emb.Optimum_EMB",
     (EngineType.OV_OPTIMUM, ModelType.RERANK): "src.engine.optimum.optimum_rr.Optimum_RR",
+    (EngineType.OV_OPTIMUM, ModelType.OPTIMUM_VLM): "src.engine.optimum.optimum_vlm.Optimum_VLM",
 }
 
 async def create_model_instance(load_config: ModelLoadConfig) -> Any:

--- a/src/server/models/registration.py
+++ b/src/server/models/registration.py
@@ -33,7 +33,8 @@ class ModelType(str, Enum):
     - qwen3_tts_voice_design: Qwen3-TTS with free-form voice description
     - qwen3_tts_voice_clone: Qwen3-TTS cloning a reference audio
     - emb: Text-to-vector models    
-    - rerank: Reranker models"""    
+    - rerank: Reranker models
+    - optimum_vlm: Optimum-Intel OpenVINO visual causal LM (no VLM token lookup)"""    
     
     LLM = "llm"
     VLM = "vlm"
@@ -45,6 +46,7 @@ class ModelType(str, Enum):
     QWEN3_TTS_VOICE_CLONE = "qwen3_tts_voice_clone"
     EMB = "emb"
     RERANK = "rerank"
+    OPTIMUM_VLM = "optimum_vlm"
 
 
 class EngineType(str, Enum):

--- a/src/server/worker_registry.py
+++ b/src/server/worker_registry.py
@@ -17,6 +17,7 @@ from src.engine.openvino.qwen3_asr.qwen3_asr import OVQwen3ASR
 from src.engine.openvino.qwen3_tts.qwen3_tts import OVQwen3TTS
 from src.engine.optimum.optimum_emb import Optimum_EMB
 from src.engine.optimum.optimum_rr import Optimum_RR
+from src.engine.optimum.optimum_vlm import Optimum_VLM
 
 from src.server.models.openvino import OV_KokoroGenConfig, OV_Qwen3ASRGenConfig, OV_Qwen3TTSGenConfig
 from src.server.models.ov_genai import OVGenAI_GenConfig, OVGenAI_WhisperGenConfig
@@ -85,6 +86,7 @@ class InferWorker:
     - infer_kokoro: Process speech generation requests
     - infer_emb: Process embedding requests
     - infer_rerank: Process reranking requests
+    - infer_optimum_vlm: Process Optimum-Intel VLM generation requests
     """
     
     @staticmethod
@@ -357,6 +359,14 @@ class InferWorker:
                 await packet.stream_queue.put(None)
                 
         return packet
+
+    @staticmethod
+    async def infer_optimum_vlm(packet: WorkerPacket, vlm_model: Optimum_VLM) -> WorkerPacket:
+        """Generate text from image for a single packet using the Optimum_VLM pipeline (stub)."""
+        # Implementation deferred: wire `vlm_model.generate_type` when inference is ready.
+        packet.response = ""
+        packet.metrics = None
+        return packet
     
 class QueueWorker:
     """
@@ -410,6 +420,33 @@ class QueueWorker:
 
             if completed_packet.metrics:
                 logger.info(f"[VLM Worker: {model_name}] Metrics: {completed_packet.metrics}")
+
+            if packet.result_future is not None and not packet.result_future.done():
+                packet.result_future.set_result(completed_packet)
+
+            model_queue.task_done()
+
+    @staticmethod
+    async def queue_worker_optimum_vlm(
+        model_name: str, model_queue: asyncio.Queue, vlm_model: Optimum_VLM, registry: ModelRegistry
+    ):
+        """Optimum VLM inference worker that processes packets from queue."""
+        logger.info(f"[Optimum VLM Worker: {model_name}] Started, waiting for packets...")
+        while True:
+            packet = await model_queue.get()
+            if packet is None:
+                logger.info(f"[Optimum VLM Worker: {model_name}] Shutdown signal received.")
+                break
+
+            completed_packet = await InferWorker.infer_optimum_vlm(packet, vlm_model)
+
+            if completed_packet.response and completed_packet.response.startswith("Error:"):
+                logger.error(f"[Optimum VLM Worker: {model_name}] Inference failed, triggering model unload...")
+                asyncio.create_task(registry.register_unload(model_name))
+                break
+
+            if completed_packet.metrics:
+                logger.info(f"[Optimum VLM Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
             if packet.result_future is not None and not packet.result_future.done():
                 packet.result_future.set_result(completed_packet)
@@ -588,6 +625,9 @@ class WorkerRegistry:
         self._model_queues_vlm: Dict[str, asyncio.Queue] = {}
         self._model_tasks_vlm: Dict[str, asyncio.Task] = {}
 
+        self._model_queues_optimum_vlm: Dict[str, asyncio.Queue] = {}
+        self._model_tasks_optimum_vlm: Dict[str, asyncio.Task] = {}
+
         self._model_queues_whisper: Dict[str, asyncio.Queue] = {}
         self._model_tasks_whisper: Dict[str, asyncio.Task] = {}
 
@@ -644,6 +684,15 @@ class WorkerRegistry:
                     self._model_queues_vlm[record.model_name] = q
                     task = asyncio.create_task(QueueWorker.queue_worker_vlm(record.model_name, q, instance, self._model_registry))
                     self._model_tasks_vlm[record.model_name] = task
+
+            elif mt == ModelType.OPTIMUM_VLM and isinstance(instance, Optimum_VLM):
+                if record.model_name not in self._model_queues_optimum_vlm:
+                    q: asyncio.Queue = asyncio.Queue()
+                    self._model_queues_optimum_vlm[record.model_name] = q
+                    task = asyncio.create_task(
+                        QueueWorker.queue_worker_optimum_vlm(record.model_name, q, instance, self._model_registry)
+                    )
+                    self._model_tasks_optimum_vlm[record.model_name] = task
 
             elif mt == ModelType.WHISPER and isinstance(instance, OVGenAI_Whisper):
                 if record.model_name not in self._model_queues_whisper:
@@ -715,6 +764,14 @@ class WorkerRegistry:
             if t is not None and not t.done():
                 t.cancel()
 
+            # Try optimum VLM dicts
+            q = self._model_queues_optimum_vlm.pop(record.model_name, None)
+            t = self._model_tasks_optimum_vlm.pop(record.model_name, None)
+            if q is not None:
+                await q.put(None)
+            if t is not None and not t.done():
+                t.cancel()
+
             # Try whisper dicts
             q = self._model_queues_whisper.pop(record.model_name, None)
             t = self._model_tasks_whisper.pop(record.model_name, None)
@@ -770,7 +827,16 @@ class WorkerRegistry:
         q = self._model_queues_vlm.get(model_name)
         if q is not None:
             return q
+        q = self._model_queues_optimum_vlm.get(model_name)
+        if q is not None:
+            return q
         raise ValueError(f"Model '{model_name}' is not loaded or no worker is available")
+
+    def _get_optimum_vlm_queue(self, model_name: str) -> asyncio.Queue:
+        q = self._model_queues_optimum_vlm.get(model_name)
+        if q is not None:
+            return q
+        raise ValueError(f"Optimum VLM model '{model_name}' is not loaded or no worker is available")
 
     def _get_whisper_queue(self, model_name: str) -> asyncio.Queue:
         q = self._model_queues_whisper.get(model_name)


### PR DESCRIPTION
@OpenArcBob
## So far
Right not this PR implements the model loading/registration/queuing patterns for optimum_vlm backend as groundwork.

## Motivation 

Optimum `OVModelForVisualCausalLM` is slower than OpenVINO GenAI `VLMPipeline` and has fewer abstractions to leverage but has other benefits; due to the complexity of adding model support in openvino client libraries we want to support testing `optimum-intel` PRs ahead of their complete integration upstream in the OpenArc project. 

## Requirements

To get this merged `Optimum_VLM` requires:

- accept an input sequence that may contain base64 images. In a serving context we assume base64 because it's how multimodal data is packaged over http. 
Here's a snippet from 1.0.5 which does some of this work;
   
```python
        try:

            images = []
            text_conversation = []
            
            for message in generation_config.conversation:
                # Check if the message content is a list (multimodal content)
                if isinstance(message.get("content", ""), list):
                    text_parts = []
                    for content_item in message["content"]:
                        # Check if this is an image content item
                        if isinstance(content_item, dict) and content_item.get("type") == "image_url":
                            image_url = content_item.get("image_url", {})
                            # Check if it's a base64 encoded image
                            if isinstance(image_url, dict) and image_url.get("url", "").startswith("data:image/"):
                                # Extract the base64 data
                                base64_data = image_url["url"].split(",", 1)
                                if len(base64_data) > 1:
                                    # Decode base64 to binary
                                    image_data = base64.b64decode(base64_data[1])
                                    # Convert to PIL Image and ensure RGB
                                    image = Image.open(BytesIO(image_data)).convert("RGB")
                                    images.append(image)
                        # If it's a text content item
                        elif isinstance(content_item, dict) and content_item.get("type") == "text":
                            text_parts.append(content_item.get("text", ""))
                    
                    # Create a new message with just the text parts
                    if text_parts:
                        text_message = message.copy()
                        text_message["content"] = " ".join(text_parts)
                        text_conversation.append(text_message)
                    else:
                        # If no text parts, still include the message with empty content
                        text_message = message.copy()
                        text_message["content"] = ""
                        text_conversation.append(text_message)
                else:
                    text_conversation.append(message)
            
            text_prompt = self.processor.apply_chat_template(
                generation_config.conversation, 
                add_generation_prompt=True
            )
            
            if images:
                inputs = self.processor(
                    text=[text_prompt],
                    images=[images],
                    padding=True, 
                    return_tensors="pt",
                    add_generation_prompt=True
                )
            else:
                inputs = self.processor(
                    text=[text_prompt],
                    padding=True, 
                    return_tensors="pt",
                    add_generation_prompt=True
                )
            
            streamer = TextIteratorStreamer(
                self.processor.tokenizer, 
                skip_prompt=True, 
                skip_special_tokens=True
            )
```
- performance metrics: prefill throughput, decode throughput, load time, inter token latency
- optimum does not expose any APIs to get this information from openvino runtime; in the ovgenai backend we can pull that data from oneapi driver callbacks. My solution in previous versions of OpenArc was to time tokenization to approximate these values. Maybe you will find a better way.
- be careful taking inspiration from [1.0.5](https://github.com/SearchSavior/OpenArc/blob/1.0.5/src/engine/optimum/optimum_image2text.py): the rewrite in october solved a ton of blocking async issues, and the optimum apis may have changed slightly since then. Other choices were bad, like requiring users to set tokens.
- Samplers; see what's available
- update documentation with examples for building an openvino PR using gemma as an example
- support `stream=False` and `stream=True`
- only support /v1/chat/completions and follow the existing the pattern
- Actually follow all patterns everywhere 


hmu with any questions but try to keep the big stuff here so we can things organized and document the adventure. 