### PR TITLE
2.0.5 support vlm bench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
-OpenArc uses bleeding edge libraries and APIs you may not be familair with. When working through a task, use the deepwiki mcp server to get *contextual* information, and the command line to investigate python surfaces.
+OpenArc uses bleeding edge libraries and APIs you may not be familair with. When working through a task, use the deepwiki mcp server to get *contextual* information, and the command line to investigate python surfaces. Prefer the command line.
 
 - When making changes, dont worry about backward compatibility; we use git for this.
 - Use uv to install dependencies
-- Respect existing patterns in the codebase
-- When the backend is changed, make sure parameters in the frontend are updated.
 - Don't rush, and ask clarifying questions.
+- In a prompt `ticks` represent grep targets

--- a/examples/utilities/evaluate_tokenization_round_trip.py
+++ b/examples/utilities/evaluate_tokenization_round_trip.py
@@ -1,0 +1,29 @@
+import random
+from transformers import AutoTokenizer
+
+MODEL_PATH = "/mnt/Ironwolf-4TB/Models/Pytorch/Qwen3.5/Qwen3.5-9B/"
+TARGET = 16384
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+vocab_size = tokenizer.vocab_size
+
+for trial in range(10):
+    raw_ids = random.sample(range(vocab_size), TARGET)
+
+    decoded = tokenizer.decode(raw_ids, skip_special_tokens=False)
+    stabilized_ids = tokenizer.encode(decoded, add_special_tokens=False)
+
+    pre_truncate = len(stabilized_ids)
+    stabilized_ids = stabilized_ids[:TARGET]
+
+    calibrated_prompt = tokenizer.decode(stabilized_ids, skip_special_tokens=False)
+    final_ids = tokenizer.encode(calibrated_prompt, add_special_tokens=False)
+
+    drift = len(final_ids) - TARGET
+    direction = "OVER" if pre_truncate >= TARGET else "SHORT"
+
+    print(
+        f"Trial {trial+1:2d}: "
+        f"after_stabilize={pre_truncate:5d}  {direction:5s} by {abs(pre_truncate - TARGET):4d}  "
+        f"after_truncate+rt={len(final_ids):5d}  drift={drift:+3d}"
+    )

--- a/src/cli/groups/bench.py
+++ b/src/cli/groups/bench.py
@@ -228,8 +228,6 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
     results_table.add_column("[cyan]run[/cyan]", justify="right")
     results_table.add_column("[cyan]d[/cyan]", justify="right")
     results_table.add_column("[cyan]p[/cyan]", justify="right")
-    if use_vlm_bench:
-        results_table.add_column("[cyan]p_actual[/cyan]", justify="right")
     results_table.add_column("[cyan]n[/cyan]", justify="right")
     results_table.add_column("[cyan]ttft(s)[/cyan]", justify="right")
     results_table.add_column("[cyan]tpot(ms)[/cyan]", justify="right")
@@ -244,8 +242,6 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
             str(result['d']),
             str(result['p']),
         ]
-        if use_vlm_bench:
-            row.append(str(int(result.get('input_token', 0))))
         row.extend([
             str(result['n']),
             f"{result['ttft']:.2f}",

--- a/src/cli/groups/bench.py
+++ b/src/cli/groups/bench.py
@@ -34,7 +34,10 @@ from ..utils import validate_model_path
 @click.pass_context
 def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, top_k, top_p, repetition_penalty):
     """- Benchmark inference with pseudo-random input tokens.
-    
+
+    LLM models send pre-encoded ``input_ids``. VLM models send a calibrated ``prompt`` string
+    (same target token count via tokenizer stabilize+truncate on the client).
+
     Examples:
         openarc bench Dolphin-X1
         openarc bench Dolphin-X1 --p 512 --n 128 -r 10
@@ -96,6 +99,9 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
     if not model_path:
         console.print("[red]model_path not found in configuration[/red]")
         ctx.exit(1)
+
+    model_type = (model_config.get('model_type') or 'llm').lower()
+    use_vlm_bench = model_type == 'vlm'
     
     # Validate model path
     if not validate_model_path(model_path):
@@ -135,16 +141,25 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
                     )
                     
                     try:
-                        # Prior context (d) + swept prompt segment (p)
-                        input_ids = OpenArcBenchmarks.random_input_ids(model_path, p, depth=depth)
-                        
-                        # Make benchmark request
                         bench_url = f"{cli_instance.base_url}/openarc/bench"
-                        payload = {
-                            "model": model_name,
-                            "input_ids": input_ids,
-                            "max_tokens": n
-                        }
+                        if use_vlm_bench:
+                            prompt = OpenArcBenchmarks.calibrated_prompt(
+                                model_path, p, depth=depth
+                            )
+                            payload = {
+                                "model": model_name,
+                                "prompt": prompt,
+                                "max_tokens": n,
+                            }
+                        else:
+                            input_ids = OpenArcBenchmarks.random_input_ids(
+                                model_path, p, depth=depth
+                            )
+                            payload = {
+                                "model": model_name,
+                                "input_ids": input_ids,
+                                "max_tokens": n,
+                            }
 
                         # Add optional parameters if provided
                         if temperature is not None:
@@ -213,6 +228,8 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
     results_table.add_column("[cyan]run[/cyan]", justify="right")
     results_table.add_column("[cyan]d[/cyan]", justify="right")
     results_table.add_column("[cyan]p[/cyan]", justify="right")
+    if use_vlm_bench:
+        results_table.add_column("[cyan]p_actual[/cyan]", justify="right")
     results_table.add_column("[cyan]n[/cyan]", justify="right")
     results_table.add_column("[cyan]ttft(s)[/cyan]", justify="right")
     results_table.add_column("[cyan]tpot(ms)[/cyan]", justify="right")
@@ -222,17 +239,22 @@ def bench(ctx, model_name, input_tokens, max_tokens, runs, depth, temperature, t
 
     
     for result in results:
-        results_table.add_row(
+        row = [
             str(result['run']),
             str(result['d']),
             str(result['p']),
+        ]
+        if use_vlm_bench:
+            row.append(str(int(result.get('input_token', 0))))
+        row.extend([
             str(result['n']),
             f"{result['ttft']:.2f}",
             f"{result['tpot']:.2f}",
             f"{result['prefill_throughput']:.1f}",
             f"{result['decode_throughput']:.1f}",
-            f"{result['decode_duration']:.2f}"
-            )
+            f"{result['decode_duration']:.2f}",
+        ])
+        results_table.add_row(*row)
     
     console.print(results_table)
     

--- a/src/cli/modules/benchmark.py
+++ b/src/cli/modules/benchmark.py
@@ -141,6 +141,57 @@ class OpenArcBenchmarks:
 
         return sample(depth) + sample(num_tokens)
 
+    @staticmethod
+    def calibrated_prompt(model_path: str, num_tokens: int, *, depth: int = 0) -> str:
+        """
+        Build a text prompt whose tokenizer will produce exactly ``depth + num_tokens``
+        tokens (BPE-stabilized: decode random IDs, re-encode, truncate, decode).
+
+        Used for VLM bench: ``VLMPipeline`` accepts only ``prompt: str``, not ``input_ids``.
+
+        Args:
+            model_path: Hugging Face tokenizer path (same as the loaded model).
+            num_tokens: Prompt segment length in tokens after optional depth prefix.
+            depth: Synthetic prior context length in tokens (default 0). Total target is d+p.
+
+        Returns:
+            Calibrated prompt string.
+
+        Raises:
+            ValueError: If the vocabulary cannot supply enough distinct non-special IDs.
+            RuntimeError: If calibration cannot satisfy the target after several attempts.
+        """
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        vocab_size = len(tokenizer)
+        special_token_ids = set(tokenizer.all_special_ids)
+        valid_token_ids = [i for i in range(vocab_size) if i not in special_token_ids]
+        target = depth + num_tokens
+
+        if target <= 0:
+            return ""
+        if target > len(valid_token_ids):
+            raise ValueError(
+                f"Need {target} distinct non-special token IDs but vocabulary only has "
+                f"{len(valid_token_ids)}."
+            )
+
+        max_attempts = 32
+        for _ in range(max_attempts):
+            raw_ids = random.sample(valid_token_ids, target)
+            decoded = tokenizer.decode(raw_ids, skip_special_tokens=False)
+            stabilized_ids = tokenizer.encode(decoded, add_special_tokens=False)
+            if len(stabilized_ids) < target:
+                continue
+            stabilized_ids = stabilized_ids[:target]
+            calibrated = tokenizer.decode(stabilized_ids, skip_special_tokens=False)
+            final_ids = tokenizer.encode(calibrated, add_special_tokens=False)
+            if len(final_ids) == target:
+                return calibrated
+
+        raise RuntimeError(
+            f"Could not calibrate prompt to exactly {target} tokens after {max_attempts} attempts."
+        )
+
 
 # Example usage:
 # if __name__ == "__main__":

--- a/src/engine/ov_genai/vlm.py
+++ b/src/engine/ov_genai/vlm.py
@@ -125,6 +125,19 @@ class OVGenAI_VLM:
 
         return tokenized_messages, ov_images
 
+    def _resolve_prompt_and_images(
+        self, gen_config: OVGenAI_GenConfig
+    ) -> Tuple[str, List[ov.Tensor]]:
+        """
+        Build (prompt, images) for VLMPipeline: bench input_ids / raw prompt / chat messages.
+        """
+        if gen_config.input_ids:
+            prompt = self.tokenizer.decode(gen_config.input_ids, skip_special_tokens=False)
+            return prompt, []
+        if gen_config.prompt:
+            return gen_config.prompt, []
+        return self.prepare_inputs(gen_config.messages, gen_config.tools)
+
     def generate_type(self, gen_config: OVGenAI_GenConfig):
         """
         Unified generation method that routes to streaming or non-streaming
@@ -143,8 +156,8 @@ class OVGenAI_VLM:
         try:
             generation_kwargs = self.create_generation_config(gen_config)
 
-            prompt, ov_images = self.prepare_inputs(gen_config.messages, gen_config.tools)
-            
+            prompt, ov_images = self._resolve_prompt_and_images(gen_config)
+
             result = await asyncio.to_thread(
                 self.model_path.generate,
                 prompt=prompt,
@@ -179,7 +192,7 @@ class OVGenAI_VLM:
         self._active_request_id = gen_config.request_id
         self._active_streamer = streamer
         
-        prompt, ov_images = self.prepare_inputs(gen_config.messages, gen_config.tools)
+        prompt, ov_images = self._resolve_prompt_and_images(gen_config)
 
         async def _run_generation():
             return await asyncio.to_thread(

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -250,10 +250,9 @@ async def get_status():
 
 @app.post("/openarc/bench", dependencies=[Depends(verify_api_key)])
 async def benchmark(request: OpenArcBenchRequest):
-    """Benchmark endpoint that accepts pre-encoded input_ids and returns only metrics."""
+    """Benchmark endpoint: pre-encoded input_ids (LLM) or calibrated prompt string (VLM). Returns only metrics."""
     try:
         config_kwargs = {
-            "input_ids": request.input_ids,
             "max_tokens": request.max_tokens,
             "temperature": request.temperature,
             "top_p": request.top_p,
@@ -261,6 +260,11 @@ async def benchmark(request: OpenArcBenchRequest):
             "repetition_penalty": request.repetition_penalty,
             "stream": False,  # Benchmarking is always non-streaming
         }
+        if request.input_ids is not None and len(request.input_ids) > 0:
+            config_kwargs["input_ids"] = request.input_ids
+        else:
+            config_kwargs["prompt"] = request.prompt
+
         # Remove keys with value None
         config_kwargs = {k: v for k, v in config_kwargs.items() if v is not None}
 
@@ -269,7 +273,10 @@ async def benchmark(request: OpenArcBenchRequest):
         result = await _workers.generate(request.model, generation_config)
         metrics = result.get("metrics", {}) or {}
         
-        logger.info(f"[bench] model={request.model} input_ids_len={len(request.input_ids)} metrics={metrics}")
+        if request.input_ids is not None and len(request.input_ids) > 0:
+            logger.info(f"[bench] model={request.model} input_ids_len={len(request.input_ids)} metrics={metrics}")
+        else:
+            logger.info(f"[bench] model={request.model} prompt_len={len(request.prompt or '')} metrics={metrics}")
         
         return {"metrics": metrics}
     except ValueError as exc:

--- a/src/server/models/requests_internal.py
+++ b/src/server/models/requests_internal.py
@@ -1,14 +1,24 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class OpenArcBenchRequest(BaseModel):
     model: str
-    input_ids: List[int]
+    input_ids: Optional[List[int]] = None
+    prompt: Optional[str] = None
     max_tokens: Optional[int] = 512
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     top_k: Optional[int] = None
     repetition_penalty: Optional[float] = None
 
+    @model_validator(mode="after")
+    def exactly_one_input(self) -> "OpenArcBenchRequest":
+        ids_ok = self.input_ids is not None and len(self.input_ids) > 0
+        prompt_ok = self.prompt is not None and self.prompt != ""
+        if ids_ok == prompt_ok:
+            raise ValueError(
+                "Provide exactly one of: input_ids (non-empty list) or prompt (non-empty string)."
+            )
+        return self


### PR DESCRIPTION
## Support benching vision language models


- `openarc bench` now supports vision language models!
- feature enables benchmarking upcoming Qwen-3.5 and Gemma4 and all other VLMs supported in OpenArc

```python
1x B70
Big-Tiger-Gemma-27B-v3-int4-asym-ov

┏━━━━━┳━━━┳━━━━━┳━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ run ┃ d ┃   p ┃   n ┃ ttft(s) ┃ tpot(ms) ┃ prefill(t/s) ┃ decode(t/s) ┃ duration(s) ┃
┡━━━━━╇━━━╇━━━━━╇━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│   1 │ 0 │ 512 │ 128 │    0.75 │    41.75 │        692.9 │        24.0 │        6.05 │
│   2 │ 0 │ 512 │ 128 │    0.26 │    41.41 │       2000.2 │        24.2 │        5.52 │
│   3 │ 0 │ 512 │ 128 │    0.26 │    41.44 │       2016.2 │        24.1 │        2.66 │
│   4 │ 0 │ 512 │ 128 │    0.26 │    41.57 │       2007.2 │        24.1 │        2.01 │
│   5 │ 0 │ 512 │ 128 │    0.26 │    41.72 │       2004.0 │        24.0 │        2.18 │
└─────┴───┴─────┴─────┴─────────┴──────────┴──────────────┴─────────────┴─────────────┘
```

## Implementation

OpenVINO GenAI's `VLMPipeline` has required ten pounds of jank to get working the way I want. This PR implements a workaround to enable getting a token count for `--p` to equal what we would expect in spite of different tokenization algorithm paradigms (BPE, Sentencepiece, etc). Since `VLMPipeline` only accepts a string `prompt` we can't sample from the models vocabulary like in the llm approach to send tokens as an array via `openvino.Tensor`; that approach guarantees `--p` and the inference code `input_tokens` match exactly. Requiring this tokenization means we can't select tokens ahead of time without having text we need to tokenize first.

To get around this I used Claude iterate on a token preprocessing loop which approximates what `VLMPipelines` internal tokenizer will count as `input_tokens` by sampling from the vocabulary as text, then encode to tokens, then decode. This is a first pass, and is very rough.

In the future I will extend to use the openvino tokenizer for this path only, mostly backend work. 

# Qwen3.5 and Gemma4 hype are more important!


