### PR TITLE
Fix: Transformers v5 changed `apply_chat_template` output to BatchEncoding

### DIFF
--- a/examples/openvino_genai/ov_genai_AutoTokenizer.py
+++ b/examples/openvino_genai/ov_genai_AutoTokenizer.py
@@ -1,6 +1,6 @@
 import openvino as ov
 from openvino_genai import GenerationConfig, LLMPipeline
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, BatchEncoding
 
 model_dir = "/mnt/Ironwolf-4TB/Models/OpenVINO/gpt-oss-nano-int4_sym-ov"
 
@@ -20,6 +20,7 @@ prompt = "You're the fastest Llama this side of the equator. What's your favorit
 messages = [{"role": "user", "content": prompt}]
 # Build proper chat prompt for Qwen-style instruct models and get prompt_token_ids directly
 prompt_token_ids = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="np", reasoning_effort="low")
+prompt_token_ids = prompt_token_ids['input_ids'] if isinstance(prompt_token_ids, BatchEncoding) else prompt_token_ids
 
 num_iterations = 3  # Number of generations to run
 

--- a/src/engine/ov_genai/continuous_batch_llm.py
+++ b/src/engine/ov_genai/continuous_batch_llm.py
@@ -3,7 +3,7 @@ import time
 from typing import List, Dict, Optional
 
 import openvino as ov
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, BatchEncoding
 from openvino_genai import (
     GenerationConfig,
     ContinuousBatchingPipeline,
@@ -92,6 +92,8 @@ class OVGenAI_ContinuousBatchText:
             skip_special_tokens=True,
             return_tensors="np",           # returns numpy.ndarray
         )
+        if isinstance(prompt_token_ids, BatchEncoding):
+            prompt_token_ids = prompt_token_ids['input_ids']
         return ov.Tensor(prompt_token_ids)
         
     def generate(self, prompts: List[List[Dict[str, str]]], generation_config: GenerationConfig):

--- a/src/engine/ov_genai/llm.py
+++ b/src/engine/ov_genai/llm.py
@@ -10,7 +10,7 @@ from openvino_genai import (
     GenerationConfig,
     LLMPipeline,
 )
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, BatchEncoding
 
 from src.server.models.ov_genai import OVGenAI_GenConfig
 from src.server.model_registry import ModelRegistry
@@ -57,6 +57,8 @@ class OVGenAI_LLM:
             skip_special_tokens=True,
             return_tensors="np"
             )
+        if isinstance(prompt_token_ids, BatchEncoding):
+            prompt_token_ids = prompt_token_ids['input_ids']
         return ov.Tensor(prompt_token_ids)
     
     def generate_type(self, gen_config: OVGenAI_GenConfig):


### PR DESCRIPTION
Previously, using `tokenizer.apply_chat_template()` would return a numpy array. With v5, however, this was changed to return an instance of `BatchEncoding` which is mainly just a dictionary with the keys `input_ids` and `attention_mask`. 

This PR corrects for the change by returning the value from the `input_ids` key. To maintain compatibility, the code first checks if the result from `apply_chat_template` is of type `BatchEncoding` before applying the fix.

I've gone through and tested all the instances I could. However, the `nncf_compress_fp8.py` example file does not have any corrections applied to it as I don't have the resources/knowledge to test it. Outside of that, there were really only two files in the source code (the continuous_batch_llm and llm engine files and a single example that needed an update, 