### PR TITLE
Kokoro: weighted voicepack blending via voice_blend

### DIFF
--- a/src/engine/openvino/kokoro.py
+++ b/src/engine/openvino/kokoro.py
@@ -132,6 +132,10 @@ class OV_Kokoro(KModel):
         from kokoro.pipeline import KPipeline
         pipeline = KPipeline(model=self, lang_code=config.lang_code.value)
 
+        # Resolve the voice once. If voice_blend is set, this returns a
+        # blended FloatTensor; otherwise the plain voice name.
+        voice_arg = self._resolve_voice(config, pipeline)
+
         text_chunks = self.make_chunks(config.input, config.character_count_chunk)
         total_chunks = len(text_chunks)
 
@@ -140,7 +144,7 @@ class OV_Kokoro(KModel):
             def infer_on_chunk():
                 """Blocking inference run in background thread."""
                 with torch.no_grad():
-                    infer = pipeline(chunk_text, voice=config.voice, speed=config.speed)
+                    infer = pipeline(chunk_text, voice=voice_arg, speed=config.speed)
                     result = next(infer) if hasattr(infer, "__iter__") else infer
                     return result
 
@@ -153,3 +157,35 @@ class OV_Kokoro(KModel):
                 chunk_index=idx,
                 total_chunks=total_chunks,
             )
+
+    @staticmethod
+    def _parse_blend(blend: str) -> list[tuple[str, float]]:
+        """Parse a blend string into [(name, weight)] with weights normalised
+        to sum to 1.0. Missing weights default to 1.0, so bare comma lists
+        become equal-weight averages. Names are validated upstream."""
+        items: list[tuple[str, float]] = []
+        for part in blend.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            name, _, weight = part.partition(":")
+            name = name.strip()
+            try:
+                w = float(weight) if weight.strip() else 1.0
+            except ValueError:
+                w = 1.0
+            items.append((name, max(0.0, w)))
+        total = sum(w for _, w in items) or 1.0
+        return [(n, w / total) for n, w in items]
+
+    def _resolve_voice(self, config: "OV_KokoroGenConfig", pipeline):
+        """Return the voice argument for KPipeline. Plain voice name when
+        voice_blend is unset, otherwise a weighted-sum FloatTensor of the
+        named voicepacks."""
+        if not getattr(config, "voice_blend", None):
+            return config.voice.value if hasattr(config.voice, "value") else config.voice
+        components = self._parse_blend(config.voice_blend)
+        if len(components) == 1:
+            return components[0][0]
+        packs = [pipeline.load_single_voice(n) * w for n, w in components]
+        return torch.stack(packs).sum(dim=0)

--- a/src/server/models/openvino.py
+++ b/src/server/models/openvino.py
@@ -94,10 +94,40 @@ class KokoroVoice(str, Enum):
 class OV_KokoroGenConfig(BaseModel):
     input: Optional[str] = Field(default=None, description="Injected from top-level request.input by the handler; do not set here.")
     voice: KokoroVoice = Field(KokoroVoice.AF_SARAH, description="Voice token from available Kokoro voices")
+    # Optional weighted blend of voicepacks. Overrides `voice` when set.
+    # Format: "af_heart,af_nicole" (equal weights) or
+    #         "af_heart:0.7,af_nicole:0.3" (weights normalised by engine).
+    voice_blend: Optional[str] = Field(
+        default=None,
+        description="Optional weighted blend of voicepacks, e.g. 'af_heart:0.7,af_nicole:0.3'. Overrides `voice`.",
+    )
     lang_code: KokoroLanguage = Field(KokoroLanguage.AMERICAN_ENGLISH, description="Language code for the voice")
     speed: float = Field(1.0, description="Speech speed multiplier")
     character_count_chunk: int = Field(100, description="Max characters per chunk")
     response_format: str = Field("wav", description="Output format")
+
+    @field_validator("voice_blend")
+    @classmethod
+    def _validate_voice_blend(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or not v.strip():
+            return None
+        parts = [p.strip() for p in v.split(",") if p.strip()]
+        if not parts:
+            return None
+        valid = {item.value for item in KokoroVoice}
+        for part in parts:
+            name, _, weight = part.partition(":")
+            name = name.strip()
+            if name not in valid:
+                raise ValueError(f"Unknown voice in blend: {name!r}")
+            if weight.strip():
+                try:
+                    w = float(weight)
+                except ValueError as exc:
+                    raise ValueError(f"Invalid weight in blend for {name!r}: {weight!r}") from exc
+                if w < 0:
+                    raise ValueError(f"Negative weight not allowed for {name!r}: {w}")
+        return v
 
 
 


### PR DESCRIPTION
Closes #98.

## Summary
- New optional `voice_blend` field on `OV_KokoroGenConfig`
- Engine resolves the blend by weighted-summing voicepack tensors and passing the result through to KPipeline (which already accepts a FloatTensor)
- Pydantic validator rejects unknown voice names with 422

## Why
Kokoro's underlying pipeline supports tensor `voice=` arguments and equal-weight name averaging via `load_voice`. The current `OV_KokoroGenConfig.voice` field is typed strictly as the `KokoroVoice` enum, so callers can't access either feature. This patch exposes arbitrary-weight mixing behind one optional field. Single-voice requests run the original code path with byte-for-byte identical output.

## Format
- `"af_heart,af_nicole"` — equal weights (matches Kokoro's existing comma syntax)
- `"af_heart:0.7,af_nicole:0.3"` — explicit weights, normalised in the engine

## Test plan
- [x] Unset `voice_blend`: identical bytes vs main
- [x] `"af_heart:0.7,af_nicole:0.3"` produces a valid 16-bit PCM WAV
- [x] `"unknown_voice:1"` returns 422 with a clear error
- [x] Weight normalisation: `"a:2,b:1"` is equivalent to `"a:0.667,b:0.333"`
- [x] Single-component blend (`"af_heart"`) bypasses the tensor path
- [x] 3-voice blend works (`"af_heart:0.5,af_nicole:0.3,bf_emma:0.2"`)

## Sample request
```json
POST /v1/audio/speech
{
  "model": "kokoro",
  "input": "Hello, world.",
  "openarc_tts": {
    "kokoro": {
      "voice": "af_heart",
      "voice_blend": "af_heart:0.7,af_nicole:0.3",
      "lang_code": "a",
      "speed": 1.0,
      "response_format": "wav"
    }
  }
}
```

Diff is +67 / -1 across two files (`src/server/models/openvino.py`, `src/engine/openvino/kokoro.py`).