### PR TITLE
make gpu_metrics a soft dependency and refactor the openarc endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "optimum[openvino]>1.26.1",
     "pip>=25.2",
     "pybind11>=3.0.3",
-    "gpu-metrics",
     "pydantic>=2.11.7",
     "pynput>=1.8.1",
     "pytest>=8.4.2",
@@ -60,7 +59,6 @@ url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.uv.sources]
-gpu-metrics = { path = "gpu-metrics" }
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 

--- a/setup.bat
+++ b/setup.bat
@@ -9,20 +9,28 @@ if %errorlevel% neq 0 (
     set "PATH=%USERPROFILE%\.local\bin;%PATH%"
 )
 
-if not exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
-    echo ERROR: Intel oneAPI not found.
-    echo install from https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
-    pause
-    exit /b 1
-)
-
-call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" intel64 --force
-
 uv sync
 call .venv\Scripts\activate.bat
 
 uv pip install "optimum-intel[openvino] @ git+https://github.com/huggingface/optimum-intel"
 uv pip install --pre -U openvino-genai --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+
+echo checking for Intel oneAPI...
+if not exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
+    echo Warning: Intel oneAPI not found. Skipping gpu-metrics install.
+    echo install from https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
+    goto :skip_gpu_metrics
+)
+
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" intel64 --force
+
+echo installing gpu-metrics (soft dependency)...
+uv pip install ./gpu-metrics
+if %errorlevel% neq 0 (
+    echo Warning: gpu-metrics build failed. Intel GPU telemetry will be unavailable.
+)
+
+:skip_gpu_metrics
 
 set /p set_key="set OPENARC_API_KEY? (y/N): "
 if /I not "%set_key%"=="y" goto :skip_key

--- a/setup.bat
+++ b/setup.bat
@@ -24,6 +24,11 @@ if not exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
 
 call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" intel64 --force
 
+if defined LEVEL_ZERO_V1_SDK_PATH (
+    echo %INCLUDE% | findstr /I /C:"%LEVEL_ZERO_V1_SDK_PATH%\include" >nul || set "INCLUDE=%INCLUDE%;%LEVEL_ZERO_V1_SDK_PATH%\include"
+    echo %LIB% | findstr /I /C:"%LEVEL_ZERO_V1_SDK_PATH%\lib" >nul || set "LIB=%LIB%;%LEVEL_ZERO_V1_SDK_PATH%\lib"
+)
+
 echo installing gpu-metrics (soft dependency)...
 uv pip install ./gpu-metrics
 if %errorlevel% neq 0 (

--- a/setup.sh
+++ b/setup.sh
@@ -9,19 +9,22 @@ if ! command -v uv &> /dev/null; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
-if [ ! -f "/opt/intel/oneapi/setvars.sh" ]; then
-    echo "ERROR: Intel oneAPI not found."
-    echo "install from https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html"
-    exit 1
-fi
-
-source /opt/intel/oneapi/setvars.sh intel64 --force
-
 uv sync
 source .venv/bin/activate
 
 uv pip install "optimum-intel[openvino] @ git+https://github.com/huggingface/optimum-intel"
 uv pip install --pre -U openvino-genai --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+
+echo "checking for Intel oneAPI..."
+if [ ! -f "/opt/intel/oneapi/setvars.sh" ]; then
+    echo "Warning: Intel oneAPI not found. Skipping gpu-metrics install."
+    echo "install from https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html"
+else
+    source /opt/intel/oneapi/setvars.sh intel64 --force
+
+    echo "installing gpu-metrics (soft dependency)..."
+    uv pip install ./gpu-metrics || echo "Warning: gpu-metrics build failed. Intel GPU telemetry will be unavailable."
+fi
 
 read -p "set OPENARC_API_KEY? (y/N): " set_key
 if [[ "$set_key" =~ ^[Yy]$ ]]; then

--- a/src/server/routes/openarc.py
+++ b/src/server/routes/openarc.py
@@ -70,7 +70,7 @@ def get_gpu_info_with_metrics():
                     used_vram=used_vram_mb,
                     usage=gpu_data.get("utilization", 0.0),
                     is_shared=is_shared,
-                ).dict()
+                ).model_dump()
             )
     except ImportError:
         is_gpu_metrics_installed = False

--- a/src/server/routes/openarc.py
+++ b/src/server/routes/openarc.py
@@ -2,6 +2,8 @@ import asyncio
 import importlib.metadata
 import json
 import logging
+from multiprocessing import cpu_count
+from operator import is_
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -19,9 +21,137 @@ from src.server.models.requests_management import (
     DownloaderRequest,
 )
 
-logger = logging.getLogger(__name__)
+import openvino as ov
 
+
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/openarc")
+
+is_gpu_metrics_installed = True
+
+class GPUInfo(BaseModel):
+    id: str
+    name: str
+    total_vram: Optional[int] = None
+    used_vram: Optional[int] = None
+    usage: Optional[float] = None
+    is_shared: Optional[bool] = None
+
+
+def get_gpu_info_with_metrics():
+    gpus = []
+    try:
+        import gpu_metrics
+
+        data = gpu_metrics.get_gpu_metrics()
+        for idx_str, gpu_data in data.items():
+            name = gpu_data.get("name", f"Intel GPU {idx_str}")
+            total_vram_mb = 0
+            used_vram_mb = 0
+            is_shared = False
+
+            mem_list = gpu_data.get("memory", [])
+            if mem_list and len(mem_list) > 0:
+                total_vram_mb = mem_list[0].get("total", 0) // (1024 * 1024)
+                used_vram_mb = mem_list[0].get("used", 0) // (1024 * 1024)
+            else:
+                import psutil
+
+                vm = psutil.virtual_memory()
+                total_vram_mb = vm.total // (1024 * 1024)
+                is_shared = True
+
+            gpus.append(
+                GPUInfo(
+                    id=idx_str,
+                    name=name,
+                    total_vram=total_vram_mb,
+                    used_vram=used_vram_mb,
+                    usage=gpu_data.get("utilization", 0.0),
+                    is_shared=is_shared,
+                ).dict()
+            )
+    except ImportError:
+        is_gpu_metrics_installed = False
+        return False, []
+    except Exception as e:
+        logging.error(f"Failed to fetch GPU metrics: {e}")
+        return False, []
+    return True, gpus
+
+
+
+def get_cpu_info():
+    cpu_info = {"id": "CPU", "name": "System CPU"}
+    try:
+        core = ov.Core()
+        devices = core.available_devices
+        for device in devices:
+            if "CPU" in device:
+                try:
+                    cpu_info["name"] = str(core.get_property(device, "FULL_DEVICE_NAME"))
+                except Exception:
+                    cpu_info["name"] = device
+                break
+    except Exception as e:
+        logging.error(f"Failed to query CPU info: {e}")
+
+    return cpu_info
+
+def get_npu_info():
+    npus = []
+    try:
+        import openvino as ov
+
+        core = ov.Core()
+        devices = core.available_devices
+        for device in devices:
+            if "NPU" in device:
+                try:
+                    name = core.get_property(device, "FULL_DEVICE_NAME")
+                except Exception:
+                    name = device
+                npus.append({"id": device, "name": str(name)})
+    except Exception as e:
+        logging.error(f"Failed to query NPU info: {e}")
+    return npus
+
+def get_gpu_info():
+    gpu_metrics_status = False
+    gpus = []
+
+    if is_gpu_metrics_installed:
+        gpu_metrics_status, gpus = get_gpu_info_with_metrics()
+
+    if not gpu_metrics_status:
+        try:
+            core = ov.Core()
+            devices = core.available_devices
+            for device in devices:
+                if "GPU" in device:
+                    try:
+                        name = core.get_property(device, "FULL_DEVICE_NAME")
+                    except Exception:
+                        name = device
+
+                    vram_bytes = core.get_property(device, "GPU_DEVICE_TOTAL_MEM_SIZE")
+                    total_vram_mb = vram_bytes // (1024 * 1024)
+                    gpus.append(
+                        GPUInfo(
+                            id=device,
+                            name=str(name),
+                            total_vram=total_vram_mb,
+                            used_vram=0,
+                            usage=0,
+                            is_shared=False,
+                        ).dict()
+                    )
+        except Exception as e:
+            logging.error(f"Failed to query GPU info: {e}")
+
+    return gpus, gpu_metrics_status
+
 
 
 @router.post("/load", dependencies=[Depends(verify_api_key)])
@@ -150,73 +280,10 @@ async def get_version():
 
 
 def get_hardware_metrics():
-    gpus = []
-    cpu_info = {"id": "CPU", "name": "System CPU"}
-    npus = []
-
-    try:
-        import cpuinfo
-
-        info = cpuinfo.get_cpu_info()
-        cpu_info["name"] = info.get("brand_raw", "System CPU")
-    except Exception as e:
-        logging.error(f"Failed to query CPU info: {e}")
-
-    try:
-        import openvino as ov
-
-        core = ov.Core()
-        devices = core.available_devices
-        for device in devices:
-            if "NPU" in device:
-                try:
-                    name = core.get_property(device, "FULL_DEVICE_NAME")
-                except Exception:
-                    name = device
-                npus.append({"id": device, "name": str(name)})
-    except Exception:
-        pass
-
-    try:
-        import gpu_metrics
-
-        data = gpu_metrics.get_gpu_metrics()
-        for idx_str, gpu_data in data.items():
-            name = gpu_data.get("name", f"Intel GPU {idx_str}")
-            total_vram_mb = 0
-            used_vram_mb = 0
-            is_shared = False
-
-            mem_list = gpu_data.get("memory", [])
-            if mem_list and len(mem_list) > 0:
-                total_vram_mb = mem_list[0].get("total", 0) // (1024 * 1024)
-                used_vram_mb = mem_list[0].get("used", 0) // (1024 * 1024)
-            else:
-                import psutil
-
-                vm = psutil.virtual_memory()
-                total_vram_mb = vm.total // (1024 * 1024)
-                is_shared = True
-
-            gpus.append(
-                {
-                    "id": f"GPU.{idx_str}",
-                    "name": str(name),
-                    "total_vram": int(total_vram_mb),
-                    "used_vram": int(used_vram_mb),
-                    "usage": 0.0,
-                    "is_shared": is_shared,
-                }
-            )
-    except ImportError:
-        logging.warning(
-            "gpu_metrics module not found. Intel GPU telemetry will be missing."
-        )
-    except Exception as e:
-        logging.error(f"Failed to fetch GPU metrics: {e}")
-
-    return {"cpu": cpu_info, "gpus": gpus, "npus": npus}
-
+    cpu_info = get_cpu_info()
+    gpu_info, gpu_metrics_status = get_gpu_info()
+    npu_info = get_npu_info()
+    return cpu_info, gpu_info, npu_info, gpu_metrics_status
 
 @router.get("/metrics", dependencies=[Depends(verify_api_key)])
 async def get_metrics():
@@ -225,11 +292,12 @@ async def get_metrics():
     vm = psutil.virtual_memory()
     hw_metrics = await asyncio.to_thread(get_hardware_metrics)
 
+    cpu_info, gpus, npus, gpu_metrics_status = hw_metrics
     return {
         "cpus": [
             {
-                "id": hw_metrics["cpu"]["id"],
-                "name": hw_metrics["cpu"]["name"],
+                "id": cpu_info["id"],
+                "name": cpu_info["name"],
                 "cores": psutil.cpu_count(logical=False) or 1,
                 "threads": psutil.cpu_count(logical=True) or 1,
                 "usage": psutil.cpu_percent(),
@@ -237,8 +305,9 @@ async def get_metrics():
         ],
         "total_ram": vm.total // (1024 * 1024),
         "used_ram": vm.used // (1024 * 1024),
-        "gpus": hw_metrics["gpus"],
-        "npus": hw_metrics["npus"],
+        "gpus": gpus,
+        "npus": npus,
+        "gpu_metrics_worked": gpu_metrics_status,
     }
 
 

--- a/src/server/routes/openarc.py
+++ b/src/server/routes/openarc.py
@@ -102,8 +102,6 @@ def get_cpu_info():
 def get_npu_info():
     npus = []
     try:
-        import openvino as ov
-
         core = ov.Core()
         devices = core.available_devices
         for device in devices:

--- a/src/server/routes/openarc.py
+++ b/src/server/routes/openarc.py
@@ -64,7 +64,7 @@ def get_gpu_info_with_metrics():
 
             gpus.append(
                 GPUInfo(
-                    id=idx_str,
+                    id=f"GPU.{idx_str}",
                     name=name,
                     total_vram=total_vram_mb,
                     used_vram=used_vram_mb,

--- a/uv.lock
+++ b/uv.lock
@@ -961,17 +961,6 @@ http = [
 ]
 
 [[package]]
-name = "gpu-metrics"
-version = "0.1.0"
-source = { directory = "gpu-metrics" }
-dependencies = [
-    { name = "pybind11" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "pybind11" }]
-
-[[package]]
 name = "grapheme"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2197,7 +2186,6 @@ dependencies = [
     { name = "click" },
     { name = "ddgs" },
     { name = "fastapi" },
-    { name = "gpu-metrics" },
     { name = "huggingface-hub", extra = ["cli"] },
     { name = "ipykernel" },
     { name = "ipywidgets" },
@@ -2231,7 +2219,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "ddgs", specifier = ">=9.6.1" },
     { name = "fastapi", specifier = ">=0.116.1" },
-    { name = "gpu-metrics", directory = "gpu-metrics" },
     { name = "huggingface-hub", extras = ["cli"], specifier = ">=0.33.4" },
     { name = "ipykernel", specifier = ">=7.0.1" },
     { name = "ipywidgets", specifier = ">=8.1.7" },


### PR DESCRIPTION
# What has been done
GPU_Metrics is now a soft dependency - it will only be installed if oneapi is available.
If its not available on the system, it will not install gpu_metrics and fall back to openvino's implementation.

Also refactored the endpoint for metrics