### PR TITLE
fix(demos): guard against empty choices and message=None in hf_agent LLM calls

### DIFF
--- a/demos/hf_explorer/hf_agent.py
+++ b/demos/hf_explorer/hf_agent.py
@@ -107,9 +107,11 @@ def chat_loop():
             tool_choice="auto"
         )
         
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         response_message = response.choices[0].message
         messages.append(response_message)
-        
+
         # Check if the model wants to call a function
         if response_message.tool_calls:
             # Execute all tool calls
@@ -132,6 +134,8 @@ def chat_loop():
                 tool_choice="auto"
             )
             
+            if not final_response.choices or final_response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             final_message = final_response.choices[0].message
             messages.append(final_message)
             print(f"\nAssistant: {final_message.content}\n")


### PR DESCRIPTION
## What

Guards both `response.choices[0]` accesses in `demos/hf_explorer/hf_agent.py` — the initial response and the follow-up after tool execution:

```python
# Initial response (line 110)
+ if not response.choices or response.choices[0].message is None:
+     raise ValueError("LLM returned empty or filtered response")
  response_message = response.choices[0].message

# Follow-up after tool calls (line 135)
+ if not final_response.choices or final_response.choices[0].message is None:
+     raise ValueError("LLM returned empty or filtered response")
  final_message = final_response.choices[0].message
```

## Why

The OpenAI API (and compatible providers) can return `choices=[]` or `choices[0].message=None` at HTTP 200 when content is filtered. Without the guard, the agent crashes with `IndexError`/`AttributeError` — there's no exception handler in the `chat_loop` function to catch these.

The tool-call path is particularly risky: if the model returns an empty response after a tool call, the follow-up call's result is also accessed without a guard, crashing mid-conversation.

## Evidence

- [Live production crash](https://github.com/HKUDS/LightRAG/issues/2551) — confirmed in the wild
- Gemini 2.5 Flash returns `choices[0].message = None` on `PROHIBITED_CONTENT` with HTTP 200
- Found by [pact](https://github.com/qizwiz/pact) across 13.5k violations in 759 repos

## Scope

1 file, 5 lines added.