### PR TITLE
Fix wheel builds not containing any `src/` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ scratchpad.md
 site/
 .cache/
 scratchpad.md
+build/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ dependencies = [
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["src"]
+[tool.setuptools.packages.find]
+include = ["src", "src.*"]
 
 [project.scripts]
 openarc = "src.cli:cli"


### PR DESCRIPTION
Clean wheel builds (`rm -rf dist/ OpenArc.egg-info/ build/ && uv build --wheel --no-sources`) currently contain no actual project files, just metadata:

```console
$ du -h dist/openarc-2.0.5-py3-none-any.whl 
8.0K    dist/openarc-2.0.5-py3-none-any.whl
$ unzip -l dist/openarc-2.0.5-py3-none-any.whl 
Archive:  dist/openarc-2.0.5-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
    11357  2026-05-22 19:44   openarc-2.0.5.dist-info/licenses/LICENSE
        0  2026-05-18 18:03   src/__init__.py
     5330  2026-05-22 19:44   openarc-2.0.5.dist-info/METADATA
       91  2026-05-22 19:44   openarc-2.0.5.dist-info/WHEEL
       40  2026-05-22 19:44   openarc-2.0.5.dist-info/entry_points.txt
        4  2026-05-22 19:44   openarc-2.0.5.dist-info/top_level.txt
      559  2026-05-22 19:44   openarc-2.0.5.dist-info/RECORD
---------                     -------
    17381                     7 files
```

This fixes the project config to include modules under `src/`:

```console
$ du -h dist/openarc-2.0.5-py3-none-any.whl 
135K    dist/openarc-2.0.5-py3-none-any.whl
```

I also added a couple of missing items to `.gitignore`.