### PR TITLE
Get config file path from `OPENARC_CONFIG_FILE` if set

### DIFF
--- a/src/cli/modules/server_config.py
+++ b/src/cli/modules/server_config.py
@@ -4,6 +4,7 @@ ServerConfig - Centralized configuration management for OpenArc.
 This module handles all configuration file operations without any CLI/presentation logic.
 """
 import json
+import os
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -16,11 +17,16 @@ class ServerConfig:
         Initialize ServerConfig with a config file path.
         
         Args:
-            config_file: Path to the config file. If None, defaults to openarc_config.json in project root.
+            config_file: Path to the config file. If None, OPENARC_CONFIG_FILE env var when set,
+            otherwise defaults to openarc_config.json in project root.
         """
         if config_file is None:
-            project_root = Path(__file__).parent.parent.parent.parent
-            config_file = project_root / "openarc_config.json"
+            env_path = os.environ.get("OPENARC_CONFIG_FILE")
+            if env_path:
+                config_file = Path(env_path)
+            else:
+                project_root = Path(__file__).parent.parent.parent.parent
+                config_file = project_root / "openarc_config.json"
         
         self.config_file = Path(config_file)
     

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -54,7 +54,8 @@ async def lifespan(app: FastAPI):
     if models:
         from pathlib import Path
 
-        config_file = Path(__file__).parent.parent.parent / "openarc_config.json"
+        env_config = os.environ.get("OPENARC_CONFIG_FILE")
+        config_file = Path(env_config) if env_config else Path(__file__).parent.parent.parent / "openarc_config.json"
         if config_file.exists():
             with open(config_file) as f:
                 config = json.load(f)


### PR DESCRIPTION
This allows the config file to be loaded from a user-specified path, allowing users to select a complete config at start time. This will also help support placing the config file on read-only volumes in a follow-up PR.