### PR TITLE
Allow loading models from paths relative to config file

### DIFF
--- a/src/cli/modules/server_config.py
+++ b/src/cli/modules/server_config.py
@@ -5,7 +5,7 @@ This module handles all configuration file operations without any CLI/presentati
 """
 import json
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, cast
 
 
 class ServerConfig:
@@ -113,21 +113,35 @@ class ServerConfig:
             model_name: Name of the model.
             
         Returns:
-            Model configuration dict, or None if not found.
+            Model configuration dict, or None if not found. Relative paths are resolved
+            against the config file's directory, allowing for configs to be packaged with models.
         """
         config = self.load_config()
-        models = config.get("models", {})
-        return models.get(model_name)
+        models = cast(Dict[str, Dict[str, Any]], config.get("models", {}))
+        model = models.get(model_name)
+        return self._resolve_model_paths(model) if model else None
     
     def get_all_models(self) -> Dict[str, Dict[str, Any]]:
         """
         Get all model configurations.
         
         Returns:
-            Dictionary mapping model names to their configurations.
+            Dictionary mapping model names to their configurations. Relative paths are resolved
+            against the config file's directory, allowing for configs to be packaged with models.
         """
         config = self.load_config()
-        return config.get("models", {})
+        models = cast(Dict[str, Dict[str, Any]], config.get("models", {}))
+        return {name: self._resolve_model_paths(cfg) for name, cfg in models.items()}
+
+    def _resolve_model_paths(self, model_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of model_config with a relative model_path made
+        absolute by joining it onto the config file's directory."""
+        resolved = dict(model_config)
+        path = resolved.get("model_path")
+        if path and not Path(path).is_absolute():
+            resolved["model_path"] = str((self.config_file.parent / path).resolve())
+
+        return resolved
     
     def remove_model_config(self, model_name: str) -> bool:
         """

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -65,6 +65,11 @@ async def lifespan(app: FastAPI):
                 if not model_config:
                     logger.warning(f"Startup: model '{name}' not in config, skipping")
                     continue
+                
+                model_path = model_config.get("model_path")
+                if model_path and not Path(model_path).is_absolute():
+                    model_config["model_path"] = str((config_file.parent / model_path).resolve())
+                
                 try:
                     await _registry.register_load(ModelLoadConfig(**model_config))
                     logger.info(f"Startup: loaded '{name}'")


### PR DESCRIPTION
Models can now be loaded from paths relative to the config file path. This is useful in conjunction with https://github.com/SearchSavior/OpenArc/pull/114, as models + their config can now be either saved to a shared cache volume, or published as OCI images.