### PR TITLE
Fix transcription endpoint requiring `openarc_asr` parameter when using Qwen3 ASR models

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -279,8 +279,7 @@ This page contains example commands to help you choose models and configure Open
           --device CPU
         ```
 
-        Use the `/v1/audio/transcriptions` endpoint with `openarc_asr` in the request body:
-        I have not tested our implementation with any community tooling yet; however, all tests using the openai python library are passing, and usually that's enough. 
+        Chunking can be configured on a per-request basis via the `openarc_asr` in the request body for the `/v1/audio/transcriptions`. If not set, the below defaults will be used. Defaults values cannot currently be configured.
 
         For the options in `extra_body`, they will likely not have support in any third party tool you don't build from scratch. I'm working on improving how these can be configured. Currently, the behavior is modified per request, so you can tinker with performance on CPU and GPU. At this time NPU device is unsupported.
 
@@ -300,6 +299,7 @@ This page contains example commands to help you choose models and configure Open
                 model="<model-name>",
                 file=f,
                 response_format="verbose_json",
+                # Optional. The below values will be used as defaults if `openarc_asr` is not provided.
                 extra_body={
                     "openarc_asr": json.dumps({
                         "qwen3_asr": {

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -510,11 +510,12 @@ async def openai_audio_transcriptions(
         normalized_model_type = ModelType(selected_model_type)
 
         if normalized_model_type == ModelType.QWEN3_ASR:
-            if not openarc_asr:
-                raise ValueError("openarc_asr required for Qwen3 ASR models")
-            cfg = OpenArcASRConfig.model_validate(json.loads(openarc_asr))
-            if not cfg.qwen3_asr:
-                raise ValueError("openarc_asr.qwen3_asr required for Qwen3 ASR models")
+            payload = json.loads(openarc_asr) if openarc_asr else {}
+            if not payload.get("qwen3_asr"):
+                # Fall back to defaults if qwen3_asr config is not provided
+                payload["qwen3_asr"] = {}
+            
+            cfg = OpenArcASRConfig.model_validate(payload)
             gen_config = cfg.qwen3_asr.model_copy(update={"audio_base64": audio_base64})
             result = await _workers.transcribe_qwen3_asr(model, gen_config)
         else:


### PR DESCRIPTION
The transcription endpoint requires the "optional" `openarc_asr` field when using Qwen3-ASR models. This makes the parameter actually optional again, falling back to model defaults. Doing this allows Qwne3-ASR models to be served in an API-compatible way with Whisper models.