### PR TITLE
Make file logging path configurable

### DIFF
--- a/src/cli/modules/launch_server.py
+++ b/src/cli/modules/launch_server.py
@@ -1,9 +1,13 @@
+import os
+
 import uvicorn
 import logging
 from pathlib import Path
 
-# Configure logging
-log_file = Path(__file__).parent.parent.parent.parent / "openarc.log"
+# Configure logging. Default to openarc.log in project root, but can be overridden with OPENARC_LOG_FILE env var.
+# Setting this to /dev/null effectively disables file logging if desired.
+default_log_file = Path(__file__).parent.parent.parent.parent / "openarc.log"
+log_file = Path(os.getenv("OPENARC_LOG_FILE", default_log_file))
 
 # Create a custom logging configuration for uvicorn
 LOG_CONFIG = {


### PR DESCRIPTION
This allows users to configure the logging path via the `OPENARC_LOG_FILE` variable. Subsequently this allows for file logging to be disabled by setting `OPENARC_LOG_FILE=/dev/null`.