### PR TITLE
precompile python and dependencies in Docker image to improve cold start times

### DIFF
--- a/Battlemage.Dockerfile
+++ b/Battlemage.Dockerfile
@@ -80,6 +80,13 @@ RUN uv sync && \
 # Add venv to PATH so openarc command works
 ENV PATH="/app/.venv/bin:$PATH"
 
+
+# ============================================================================
+# Precompile Python bytecode to avoid slow first-start imports.
+# ============================================================================
+RUN python -m compileall -q /app/src /app/.venv/lib/python3.12/site-packages
+
+
 # ============================================================================
 # Runtime Configuration
 # ============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,11 @@ RUN uv sync && \
 ENV PATH="/app/.venv/bin:$PATH"
 
 # ============================================================================
+# Precompile Python bytecode to avoid slow first-start imports.
+# ============================================================================
+RUN python -m compileall -q /app/src /app/.venv/lib/python3.12/site-packages
+
+# ============================================================================
 # Runtime Configuration
 # ============================================================================
 ENV NEOReadDebugKeys=1 \


### PR DESCRIPTION
Related to #111 , as I dug into why the startup was taking so long which was the root cause of the issue, I realized that on a cold startup (right after a docker image pull or a container recreate) `openarc serve start` takes a long time (~70sec on my machine) yet a docker restart of the container starts in a fraction of the time.

Turns out it's the initial compilation of the dependencies that was taking so long on the first / cold start.

Moving the compilation into the Dockerfile and creating an image with the bytecode already included shrinks the `openarc serve start` to 5 seconds (on my machine) improving the consistency of startup, whether a 'warm' restart or a fresh / recreated container. Of course, the downside is that the docker image takes additional time to build. If an official docker image were maintained however, this would improve the startup time after pulling an update etc.