### PR TITLE
deprecate vlm-type argument from ModelLoadConfig

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,7 +13,7 @@ This page contains example commands to help you choose models and configure Open
 
     Add a model to `openarc_config.json` for easy loading with `openarc load`.
 
-    === "Single device"
+    === "Required"
 
         ```
         openarc add \
@@ -26,6 +26,18 @@ This page contains example commands to help you choose models and configure Open
 
         To see what options you have for `--device`, use `openarc tool device-detect`.
 
+
+    === "LLM"
+
+        ```
+        openarc add \
+          --model-name <model-name> \
+          --model-path <path/to/model> \
+          --engine <engine> \
+          --model-type llm \
+          --device <target-device>
+        ```
+    
     === "VLM"
 
         ```
@@ -33,30 +45,10 @@ This page contains example commands to help you choose models and configure Open
           --model-name <model-name> \
           --model-path <path/to/model> \
           --engine <engine> \
-          --model-type <model-type> \
-          --device <target-device> \
-          --vlm-type <vlm-type>
+          --model-type vlm \
+          --device <target-device>
         ```
-
-        Getting VLM to work the way I wanted required using VLMPipeline in ways that are not well documented. You can look at the [code](src/engine/ov_genai/vlm.py#L33) to see how OpenArc's VLM backend passes images. Basically, it involves slicing the input sequence by scanning for when there's in image and injecting appropriate tokens. Honestly I have no ideas why they built VLMPipeline this way, but to support all the architectures my approach was easier in the end.
-
-        `vlm-type` maps a vision token for a given architecture. Use `openarc add --help` to see the available options. The server will complain if you get anything wrong, so it should be easy to figure out.
-
-
-        NOTE: you don't have to pass `Vision Token`; these are mapped to the `vlm-type` `openarc add` argument so use that instead. 
-
-        | `--vlm-type`   | Vision token                                        |
-        |----------------|-----------------------------------------------------|
-        | `internvl2`    | `<image>`                                           |
-        | `llava15`      | `<image>`                                           |
-        | `llavanext`    | `<image>`                                           |
-        | `minicpmv26`   | `(<image>./</image>)`                               |
-        | `phi3vision`   | `<\|image_{i}\|>`                                   |
-        | `phi4mm`       | `<\|image_{i}\|>`                                   |
-        | `qwen2vl`      | `<\|vision_start\|><\|image_pad\|><\|vision_end\|>` |
-        | `qwen25vl`     | `<\|vision_start\|><\|image_pad\|><\|vision_end\|>` |
-        | `gemma3`       | `<start_of_image>`                                  |
-
+    
     === "Whisper"
 
         ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -106,7 +106,7 @@ If you need help converting a particular model join Discord and we can help you!
 
 Qwen3.5 models has unofficial support. However, they do require you to build `openvino` and `openvino.genai` from source. You will also need to install the latest version of `optimum-intel`. 
 
-To add a model, run the command `openarc add --model-name MODEL_NAME --model-path /path/to/model --model-type vlm --device GPU|CPU --runtime-config '{"ATTENTION_BACKEND": "SDPA"}' --vlm-type qwen35`. Intel is currently working on adding support for Qwen3.5 to utilize the PA attention backend but it has not been merged yet. This currently appears to be much more performant. If you have built `openvino.genai` with the support included, you may change the runtime config parameter to use PA instead.
+To add a model, run the command `openarc add --model-name MODEL_NAME --model-path /path/to/model --model-type vlm --device GPU|CPU --runtime-config '{"ATTENTION_BACKEND": "SDPA"}'`. OpenArc resolves the VLM vision token from the model's `config.json`. Intel is currently working on adding support for Qwen3.5 to utilize the PA attention backend but it has not been merged yet. This currently appears to be much more performant. If you have built `openvino.genai` with the support included, you may change the runtime config parameter to use PA instead.
 
 **How do I control thinking?**
 

--- a/src/cli/groups/add.py
+++ b/src/cli/groups/add.py
@@ -34,11 +34,6 @@ from ..utils import validate_model_path
 @click.option("--runtime-config", "--rtc",
     default=None,
     help='OpenVINO runtime configuration as JSON string (e.g., \'{"MODEL_DISTRIBUTION_POLICY": "PIPELINE_PARALLEL"}\').')
-@click.option('--vlm-type', '--vt',
-    type=click.Choice(['internvl2', 'llava15', 'llavanext', 'minicpmv26', 'phi3vision', 'phi4mm', 'qwen2vl', 'qwen25vl', 'qwen3vl', 'qwen35', 'gemma3', 'gemma4']),
-    required=False,
-    default=None,
-    help='Vision model type. Used to map correct vision tokens.')
 @click.option('--draft-model-path', '--dmp',
     required=False,
     default=None,
@@ -58,7 +53,7 @@ from ..utils import validate_model_path
     type=float,
     help='Confidence threshold for accepting draft tokens.')
 @click.pass_context
-def add(ctx, model_path, model_name, engine, model_type, device, runtime_config, vlm_type, draft_model_path, draft_device, num_assistant_tokens, assistant_confidence_threshold):
+def add(ctx, model_path, model_name, engine, model_type, device, runtime_config, draft_model_path, draft_device, num_assistant_tokens, assistant_confidence_threshold):
     """- Add a model configuration to the config file."""
     
     # Validate model path
@@ -80,7 +75,7 @@ def add(ctx, model_path, model_name, engine, model_type, device, runtime_config,
             console.print('[yellow]Example format: \'{"MODEL_DISTRIBUTION_POLICY": "PIPELINE_PARALLEL"}\'[/yellow]')
             ctx.exit(1)
     
-    # Build and save configuration
+    # Legacy configs may still contain vlm_type, but new configs resolve VLM tokens from config.json.
     load_config = {
         "model_name": model_name,
         "model_path": model_path,  
@@ -88,7 +83,6 @@ def add(ctx, model_path, model_name, engine, model_type, device, runtime_config,
         "engine": engine,    
         "device": device,
         "runtime_config": parsed_runtime_config,
-        "vlm_type": vlm_type if vlm_type else None
     }
     
     # Add speculative decoding options if provided

--- a/src/engine/ov_genai/vlm.py
+++ b/src/engine/ov_genai/vlm.py
@@ -15,8 +15,9 @@ from openvino_genai import (
 from PIL import Image
 from transformers import AutoTokenizer
 
-from src.server.models.ov_genai import OVGenAI_GenConfig, VLM_VISION_TOKENS
+from src.server.models.ov_genai import OVGenAI_GenConfig
 from src.server.utils.chat import flatten_message_content
+from src.server.utils.resolve_vlm_type import resolve_vlm_vision_token
 from src.server.model_registry import ModelRegistry
 from src.server.models.registration import ModelLoadConfig
 from src.engine.ov_genai.streamers import ChunkStreamer
@@ -278,15 +279,13 @@ class OVGenAI_VLM:
             
             self.tokenizer = AutoTokenizer.from_pretrained(loader.model_path)
     
-            # Get vision token from the mapping using vlm_type as key
-            self.vision_token = VLM_VISION_TOKENS.get(loader.vlm_type)
-            if self.vision_token is None:
-                raise ValueError(f"Unknown VLM type: {loader.vlm_type}. Supported: {list(VLM_VISION_TOKENS.keys())}")
+            self.vision_token = resolve_vlm_vision_token(loader.model_path)
 
             logger.info(f"{loader.model_name} loaded successfully")
 
         except Exception as e:
             logger.error(f"[{loader.model_name}] Failed to initialize VLMPipeline: {e}", exc_info=True)
+            raise
 
     async def unload_model(self, registry: ModelRegistry, model_name: str) -> bool:
         """

--- a/src/server/models/ov_genai.py
+++ b/src/server/models/ov_genai.py
@@ -96,20 +96,3 @@ class OVGenAI_GenConfig(BaseModel):
 
 class OVGenAI_WhisperGenConfig(BaseModel):
     audio_base64: str = Field(..., description="Base64 encoded audio")
-
-VLM_VISION_TOKENS = {
-    "internvl2": "<image>",
-    "llava15": "<image>",
-    "llavanext": "<image>",
-    "minicpmv26": "(<image>./</image>)",
-    "phi3vision": "<|image_{i}|>",
-    "phi4mm": "<|image_{i}|>",
-    "qwen2vl": "<|vision_start|><|image_pad|><|vision_end|>",
-    "qwen25vl": "<|vision_start|><|image_pad|><|vision_end|>",
-    "qwen3vl": "<|vision_start|><|image_pad|><|vision_end|>",
-    "qwen35": "<|vision_start|><|image_pad|><|vision_end|>",
-    "gemma3": "<start_of_image>",
-    "gemma4": "<|image><|image|><image|>"
-    
-}
-

--- a/src/server/models/registration.py
+++ b/src/server/models/registration.py
@@ -1,9 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, field_validator
-
-from src.server.models.ov_genai import VLM_VISION_TOKENS
+from pydantic import BaseModel, Field
 
 
 class ModelStatus(str, Enum):
@@ -75,7 +73,7 @@ class ModelLoadConfig(BaseModel):
     model_type: ModelType = Field(...)
     vlm_type: Optional[str] = Field(
         default=None,
-        description=f"Vision token type for VLM models. Supported: {list(VLM_VISION_TOKENS.keys())}"
+        description="Deprecated legacy VLM token type. VLM tokens are resolved from config.json."
     )
     engine: EngineType = Field(...)
     device: str = Field(
@@ -105,17 +103,6 @@ class ModelLoadConfig(BaseModel):
         description="Default assistant_confidence_threshold for speculative decoding with this model"
     )
     
-    @field_validator('vlm_type')
-    @classmethod
-    def validate_vlm_type(cls, v, info):
-        # Only validate if vlm_type is provided and model_type is VLM
-        if v is None:
-            return v
-        if v not in VLM_VISION_TOKENS:
-            raise ValueError(f"vlm_type must be one of {list(VLM_VISION_TOKENS.keys())}, got '{v}'")
-        return v
-
 
 class ModelUnloadConfig(BaseModel):
     model_name: str = Field(..., description="Name of the model to unload")
-

--- a/src/server/utils/resolve_vlm_type.py
+++ b/src/server/utils/resolve_vlm_type.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ARCHITECTURE_VISION_TOKENS = {
+    "Gemma4ForConditionalGeneration": "<|image><|image|><image|>",
+    "Gemma3ForConditionalGeneration": "<start_of_image>",
+    "Qwen3_5ForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
+    "Qwen3VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
+    "Qwen2_5_VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
+    "Qwen2VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
+    "InternVLChatModel": "<image>",
+    "InternVLForConditionalGeneration": "<image>",
+    "LlavaForConditionalGeneration": "<image>",
+    "LlavaNextForConditionalGeneration": "<image>",
+    "MiniCPMV": "(<image>./</image>)",
+    "MiniCPMVForCausalLM": "(<image>./</image>)",
+    "Phi3VForCausalLM": "<|image_{i}|>",
+    "Phi3VisionForCausalLM": "<|image_{i}|>",
+    "Phi4MMForCausalLM": "<|image_{i}|>",
+}
+
+
+def _architecture_values(config: Any) -> Iterable[str]:
+    if not isinstance(config, dict):
+        return ()
+
+    architectures = config.get("architectures")
+    if isinstance(architectures, str):
+        return (architectures,)
+    if isinstance(architectures, list):
+        return tuple(item for item in architectures if isinstance(item, str))
+    return ()
+
+
+def _token_from_architectures(architectures: Iterable[str]) -> str | None:
+    for architecture in architectures:
+        token = ARCHITECTURE_VISION_TOKENS.get(architecture)
+        if token is not None:
+            return token
+    return None
+
+
+def _token_from_raw_config(config_text: str) -> str | None:
+    for architecture, token in ARCHITECTURE_VISION_TOKENS.items():
+        if architecture in config_text:
+            return token
+    return None
+
+
+def _drop_model_type(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _drop_model_type(item)
+            for key, item in value.items()
+            if key != "model_type"
+        }
+    if isinstance(value, list):
+        return [_drop_model_type(item) for item in value]
+    return value
+
+
+def supported_architectures() -> list[str]:
+    return list(ARCHITECTURE_VISION_TOKENS.keys())
+
+
+def resolve_vlm_vision_token(model_path: str) -> str:
+    config_path = Path(model_path) / "config.json"
+
+    try:
+        config_text = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(
+            f"Could not read VLM config.json at {config_path}. Supported architectures: "
+            f"{', '.join(supported_architectures())}"
+        ) from exc
+
+    try:
+        config = json.loads(config_text)
+    except json.JSONDecodeError:
+        config = None
+
+    architecture_token = _token_from_architectures(_architecture_values(config))
+    if architecture_token is not None:
+        return architecture_token
+
+    scan_text = config_text
+    if config is not None:
+        scan_text = json.dumps(_drop_model_type(config))
+
+    scan_token = _token_from_raw_config(scan_text)
+    if scan_token is not None:
+        return scan_token
+
+    raise ValueError(
+        f"Could not resolve VLM vision token from {config_path}. Supported architectures: "
+        f"{', '.join(supported_architectures())}"
+    )

--- a/src/tests/test_cli_add_unit.py
+++ b/src/tests/test_cli_add_unit.py
@@ -1,0 +1,49 @@
+import json
+
+from click.testing import CliRunner
+
+from src.cli import cli
+
+
+def _model_dir(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "openvino_model.xml").write_text("<xml />", encoding="utf-8")
+    (model_dir / "openvino_model.bin").write_bytes(b"bin")
+    return model_dir
+
+
+def test_add_help_omits_vlm_type_option() -> None:
+    result = CliRunner().invoke(cli, ["add", "--help"])
+
+    assert result.exit_code == 0
+    assert "--vlm-type" not in result.output
+    assert "--vt" not in result.output
+
+
+def test_add_does_not_save_vlm_type(tmp_path) -> None:
+    config_file = tmp_path / "openarc_config.json"
+    model_dir = _model_dir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "add",
+            "--model-name",
+            "test-vlm",
+            "--model-path",
+            str(model_dir),
+            "--engine",
+            "ovgenai",
+            "--model-type",
+            "vlm",
+            "--device",
+            "CPU",
+        ],
+        env={"OPENARC_CONFIG_FILE": str(config_file)},
+    )
+
+    assert result.exit_code == 0
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    model_config = config["models"]["test-vlm"]
+    assert "vlm_type" not in model_config

--- a/src/tests/test_ov_genai_vlm_unit.py
+++ b/src/tests/test_ov_genai_vlm_unit.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -53,7 +55,6 @@ def load_config() -> ModelLoadConfig:
         engine=EngineType.OV_GENAI,
         device="CPU",
         runtime_config={"config": "value"},
-        vlm_type="internvl2",
     )
 
 
@@ -153,7 +154,12 @@ def test_collect_metrics_prefill_throughput(load_config: ModelLoadConfig) -> Non
     assert metrics["stream_chunk_tokens"] == 2
 
 
-def test_load_model_sets_pipeline_and_vision_token(monkeypatch: pytest.MonkeyPatch, load_config: ModelLoadConfig) -> None:
+def test_load_model_sets_pipeline_and_vision_token(monkeypatch: pytest.MonkeyPatch, tmp_path, load_config: ModelLoadConfig) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps({"architectures": ["Qwen2_5_VLForConditionalGeneration"]}),
+        encoding="utf-8",
+    )
+    load_config.model_path = str(tmp_path)
     vlm = OVGenAI_VLM(load_config)
     pipeline_instance = MagicMock()
     pipeline_factory = MagicMock(return_value=pipeline_instance)
@@ -176,11 +182,10 @@ def test_load_model_sets_pipeline_and_vision_token(monkeypatch: pytest.MonkeyPat
     vlm_module.AutoTokenizer.from_pretrained.assert_called_once_with(load_config.model_path)
     assert vlm.model_path is pipeline_instance
     assert vlm.tokenizer is tokenizer_instance
-    assert vlm.vision_token == vlm_module.VLM_VISION_TOKENS[load_config.vlm_type]
+    assert vlm.vision_token == "<|vision_start|><|image_pad|><|vision_end|>"
 
 
-@pytest.mark.asyncio
-async def test_unload_model_resets_state(monkeypatch: pytest.MonkeyPatch, load_config: ModelLoadConfig) -> None:
+def test_unload_model_resets_state(monkeypatch: pytest.MonkeyPatch, load_config: ModelLoadConfig) -> None:
     vlm = OVGenAI_VLM(load_config)
     vlm.model_path = object()
     vlm.tokenizer = object()
@@ -192,7 +197,10 @@ async def test_unload_model_resets_state(monkeypatch: pytest.MonkeyPatch, load_c
     gc_mock = MagicMock()
     monkeypatch.setattr(vlm_module.gc, "collect", gc_mock)
 
-    result = await vlm.unload_model(registry, "model-name")
+    async def _run():
+        return await vlm.unload_model(registry, "model-name")
+
+    result = asyncio.run(_run())
 
     assert result is True
     assert vlm.model_path is None
@@ -200,4 +208,3 @@ async def test_unload_model_resets_state(monkeypatch: pytest.MonkeyPatch, load_c
     assert vlm.vision_token is None
     registry.register_unload.assert_called_once_with("model-name")
     gc_mock.assert_called_once()
-

--- a/src/tests/test_resolve_vlm_type.py
+++ b/src/tests/test_resolve_vlm_type.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest  # type: ignore[import]
+
+from src.server.utils.resolve_vlm_type import resolve_vlm_vision_token
+
+
+def _write_config(model_dir, config) -> None:
+    model_dir.mkdir(exist_ok=True)
+    (model_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_resolves_token_from_architectures_list(tmp_path) -> None:
+    _write_config(
+        tmp_path,
+        {"architectures": ["Qwen2_5_VLForConditionalGeneration"]},
+    )
+
+    assert resolve_vlm_vision_token(str(tmp_path)) == "<|vision_start|><|image_pad|><|vision_end|>"
+
+
+def test_resolves_token_from_architectures_string(tmp_path) -> None:
+    _write_config(tmp_path, {"architectures": "Gemma4ForConditionalGeneration"})
+
+    assert resolve_vlm_vision_token(str(tmp_path)) == "<|image><|image|><image|>"
+
+
+def test_raw_scan_fallback_ignores_model_type_key(tmp_path) -> None:
+    _write_config(
+        tmp_path,
+        {
+            "model_type": "Gemma3ForConditionalGeneration",
+            "text_config": {"auto_map": "Qwen3VLForConditionalGeneration"},
+        },
+    )
+
+    assert resolve_vlm_vision_token(str(tmp_path)) == "<|vision_start|><|image_pad|><|vision_end|>"
+
+
+def test_vlm_type_does_not_fallback_when_config_has_no_known_architecture(tmp_path) -> None:
+    _write_config(tmp_path, {"architectures": ["UnknownForConditionalGeneration"]})
+
+    with pytest.raises(ValueError, match="Supported architectures"):
+        resolve_vlm_vision_token(str(tmp_path))
+
+
+def test_missing_config_raises_clear_error(tmp_path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    with pytest.raises(ValueError, match="Could not read VLM config.json"):
+        resolve_vlm_vision_token(str(tmp_path))
+
+
+def test_unknown_architecture_raises_clear_error(tmp_path) -> None:
+    _write_config(tmp_path, {"architectures": ["UnknownForConditionalGeneration"]})
+
+    with pytest.raises(ValueError, match="Supported architectures"):
+        resolve_vlm_vision_token(str(tmp_path))
+
+
+def test_config_model_type_is_ignored_even_when_it_contains_supported_architecture(tmp_path) -> None:
+    _write_config(tmp_path, {"model_type": "Gemma4ForConditionalGeneration"})
+
+    with pytest.raises(ValueError, match="Supported architectures"):
+        resolve_vlm_vision_token(str(tmp_path))


### PR DESCRIPTION
OpenArc implements a manual strategy for interleaving images with text for vision language models. 

Previously the approach was to require an argument per model, `--vlm-type`, which tells `OVGenAIVLM` what a given model's image tokens are. All this work is to support `AutoTokenizer`, which has better chat templating features than OpenVINO genai provides. 

This PR makes a QOL change recently suggested by @WizardlyBump17, motivated earlier by @mrelmida for usability in studio. I decided to use the "architectures" key in the `transformers` `config.json`, since we can be sure its always exists- without that key, model conversion to openvino format would have failed so there is some safety. Upstream they implement vision models individualy, so we have to maintain this code anyway to support enabled vision language models.

Here is the exact lookup table from `src/server/utils/resolve_vlm_type.py`

```
ARCHITECTURE_VISION_TOKENS = {
    "Gemma4ForConditionalGeneration": "<|image><|image|><image|>",
    "Gemma3ForConditionalGeneration": "<start_of_image>",
    "Qwen3_5ForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
    "Qwen3VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
    "Qwen2_5_VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
    "Qwen2VLForConditionalGeneration": "<|vision_start|><|image_pad|><|vision_end|>",
    "InternVLChatModel": "<image>",
    "InternVLForConditionalGeneration": "<image>",
    "LlavaForConditionalGeneration": "<image>",
    "LlavaNextForConditionalGeneration": "<image>",
    "MiniCPMV": "(<image>./</image>)",
    "MiniCPMVForCausalLM": "(<image>./</image>)",
    "Phi3VForCausalLM": "<|image_{i}|>",
    "Phi3VisionForCausalLM": "<|image_{i}|>",
    "Phi4MMForCausalLM": "<|image_{i}|>",
}
```

## Notes

- existing model configs will not break, vlm-type is not sent in the request
- the check is scoped to cases where `model-type= vlm`
- I haven't reviewed if there are any changes neccesary in studio, will check tonight.
- docs have been updated

