### PR TITLE
Fix bugs with relative model path resolution

### DIFF
--- a/src/cli/groups/add.py
+++ b/src/cli/groups/add.py
@@ -93,6 +93,9 @@ def add(ctx, model_path, model_name, engine, model_type, device, runtime_config,
     
     # Add speculative decoding options if provided
     if draft_model_path:
+        if not validate_model_path(draft_model_path):
+            console.print(f"[red]Model file check failed! {draft_model_path} does not contain openvino model files OR your chosen path is malformed. Verify chosen path is correct and acquired model files match source on the hub, or the destination of converted model.[/red]")
+            ctx.exit(1)
         load_config["draft_model_path"] = draft_model_path
     if draft_device:
         load_config["draft_device"] = draft_device

--- a/src/cli/modules/server_config.py
+++ b/src/cli/modules/server_config.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 from typing import Optional, Dict, Any, List, cast
+from ..utils import get_config_file_path
 
 
 class ServerConfig:
@@ -20,15 +21,7 @@ class ServerConfig:
             config_file: Path to the config file. If None, OPENARC_CONFIG_FILE env var when set,
             otherwise defaults to openarc_config.json in project root.
         """
-        if config_file is None:
-            env_path = os.environ.get("OPENARC_CONFIG_FILE")
-            if env_path:
-                config_file = Path(env_path)
-            else:
-                project_root = Path(__file__).parent.parent.parent.parent
-                config_file = project_root / "openarc_config.json"
-        
-        self.config_file = Path(config_file)
+        self.config_file = get_config_file_path() if config_file is None else config_file
     
     def load_config(self) -> Dict[str, Any]:
         """
@@ -155,9 +148,14 @@ class ServerConfig:
         """Return a copy of model_config with a relative model_path made
         absolute by joining it onto the config file's directory."""
         resolved = dict(model_config)
+
         path = resolved.get("model_path")
         if path and not Path(path).is_absolute():
             resolved["model_path"] = str((self.config_file.parent / path).resolve())
+
+        draft_model_path = resolved.get("draft_model_path")
+        if draft_model_path and not Path(draft_model_path).is_absolute():
+            resolved["draft_model_path"] = str((self.config_file.parent / draft_model_path).resolve())
 
         return resolved
     

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for OpenArc CLI.
 """
+import os
 from pathlib import Path
 
 
@@ -21,6 +22,11 @@ def validate_model_path(model_path):
         search_dir = path.parent
     else:
         search_dir = path
+        
+    if not search_dir.is_absolute():
+        # Search relative to the config file directory
+        config_file =  get_config_file_path()
+        search_dir = (config_file.parent / search_dir).resolve()
     
     # Check for required files
     has_bin = False
@@ -40,3 +46,15 @@ def validate_model_path(model_path):
         return False
     
     return False
+
+def get_config_file_path():
+    """
+    Get the path to the config file, checking the OPENARC_CONFIG_FILE environment variable first,
+    then defaulting to openarc_config.json in the project root.
+    """
+    env_path = os.environ.get("OPENARC_CONFIG_FILE")
+    if env_path:
+        return Path(env_path)
+    else:
+        project_root = Path(__file__).parent.parent.parent
+        return project_root / "openarc_config.json"

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from src.cli.utils import get_config_file_path
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.server.deps import _registry
@@ -54,8 +55,7 @@ async def lifespan(app: FastAPI):
     if models:
         from pathlib import Path
 
-        env_config = os.environ.get("OPENARC_CONFIG_FILE")
-        config_file = Path(env_config) if env_config else Path(__file__).parent.parent.parent / "openarc_config.json"
+        config_file = get_config_file_path()
         if config_file.exists():
             with open(config_file) as f:
                 config = json.load(f)


### PR DESCRIPTION
While working on some doc updates I found a couple of bugs with https://github.com/SearchSavior/OpenArc/pull/116:
* Draft model paths are not resolved relative to the config
* The `openarc add` command does not resolve model paths relative to the config

This fixes both issues, and moves the config file path resolution logic to a single function.