### PR TITLE
Fix `transcribe` Qwen3-ASR models blocking other API calls

### DIFF
--- a/src/engine/openvino/qwen3_asr/qwen3_asr.py
+++ b/src/engine/openvino/qwen3_asr/qwen3_asr.py
@@ -265,7 +265,7 @@ class OVQwen3ASR:
             "encoder_tokens": encoder_tokens,
         }
 
-    async def audio_chunks(self, chunk_audio: np.ndarray, max_tokens: int):
+    def audio_chunks(self, chunk_audio: np.ndarray, max_tokens: int):
         t_feature_start = time.perf_counter()
         mel = Qwen3ASRHelpers.compute_mel_spectrogram(chunk_audio, self.mel_filters)
         t_feature = time.perf_counter() - t_feature_start
@@ -387,7 +387,9 @@ class OVQwen3ASR:
                 f"[{self.load_config.model_name}] Chunk {idx + 1}/{len(chunk_items)} "
                 f"offset={chunk_offset_sec:.2f}s duration={chunk_sec:.2f}s"
             )
-            raw, chunk_metrics = await self.audio_chunks(chunk_wav, gen_config.max_tokens)
+            raw, chunk_metrics = await asyncio.to_thread(
+                self.audio_chunks, chunk_wav, gen_config.max_tokens
+            )
             lang, text = parse_asr_output(raw, language=language)
             langs.append(lang)
             if text:


### PR DESCRIPTION
The `audio_chunks` function is marked as `async`, causing it to run in the FastAPI event loop. This blocks other API endpoint handlers, as there is no async work actually done by this function. As a result, requests like health check calls to the `/status` endpoint time out as FastAPI won't process them until transcription is complete.

This removes the `async` marker and runs the function in its own thread, making it actually awaitable.