### PR TITLE
chore: Refactor some tests

### DIFF
--- a/src/tests/test_model_registry_unit.py
+++ b/src/tests/test_model_registry_unit.py
@@ -137,5 +137,5 @@ def test_create_model_instance_rejects_unknown_combination() -> None:
 
 def test_model_class_registry_includes_qwen3_asr() -> None:
     key = (EngineType.OPENVINO, ModelType.QWEN3_ASR)
-    assert registry_module.MODEL_CLASS_REGISTRY[key] == "src.engine.openvino.qwen3_asr.infer.OVQwen3ASR"
+    assert registry_module.MODEL_CLASS_REGISTRY[key] == "src.engine.openvino.qwen3_asr.qwen3_asr.OVQwen3ASR"
 

--- a/src/tests/test_optimum_emb_integration.py
+++ b/src/tests/test_optimum_emb_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,8 +10,11 @@ from src.engine.optimum.optimum_emb import Optimum_EMB
 from src.server.models.registration import EngineType, ModelLoadConfig, ModelType
 from src.server.models.optimum import PreTrainedTokenizerConfig
 
+# Inject "TEST_MODEL_PATH" environment variable during tests to override the default model path.
+#  - on windows be sure to escape backslashes."
+TEST_MODEL_PATH = os.getenv("TEST_MODEL_PATH", r"/mnt/Ironwolf-4TB/Models/Pytorch/Qwen/")
 
-MODEL_PATH = Path("/mnt/Ironwolf-4TB/Models/Pytorch/Qwen/Qwen3-Embed-0.6B-INT8-ASYM-ov")
+MODEL_PATH = Path(TEST_MODEL_PATH) / "Qwen3-Embedding-0.6B-int8_asym-ov"
 UNIT_TEST_PATH = Path(__file__).with_name("test_optimum_emb_unit.py")
 
 _UNIT_TESTS_PASSED: bool | None = None

--- a/src/tests/test_optimum_rr_integration.py
+++ b/src/tests/test_optimum_rr_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,8 +10,9 @@ from src.engine.optimum.optimum_rr import Optimum_RR
 from src.server.models.registration import EngineType, ModelLoadConfig, ModelType
 from src.server.models.optimum import RerankerConfig
 
+TEST_MODEL_PATH = os.getenv("TEST_MODEL_PATH", r"/mnt/Ironwolf-4TB/Models/OpenVINO/Qwen/")
 
-MODEL_PATH = Path("/mnt/Ironwolf-4TB/Models/OpenVINO/Qwen/Qwen3-Reranker-0.6B-fp16-ov")
+MODEL_PATH = Path(TEST_MODEL_PATH) / "Qwen3-Reranker-0.6B-fp16-ov"
 UNIT_TEST_PATH = Path(__file__).with_name("test_optimum_rr_unit.py")
 
 _UNIT_TESTS_PASSED: bool | None = None

--- a/src/tests/test_optimum_rr_unit.py
+++ b/src/tests/test_optimum_rr_unit.py
@@ -79,8 +79,8 @@ def test_generate_rerankings_orders_documents(monkeypatch: pytest.MonkeyPatch, l
     rr.tokenizer = DummyTokenizer()
 
     logits = torch.tensor([
-        [[0.0, 0.0, 0.0], [2.0, -1.0, 0.5]],
-        [[0.0, 0.0, 0.0], [0.5, 1.5, -0.2]],
+        [[0.0, 0.0, 0.0], [0.5, 2.0, -0.2]],   # Paris: true high
+        [[0.0, 0.0, 0.0], [2.0, -1.0, 0.5]],   # Berlin: false high
     ])
 
     class DummyModel:


### PR DESCRIPTION
- `test_optimum_emb_integration.py` 
   - First test to use `TEST_MODEL_PATH` environment variable, this might be a pattern to use across tests so people running tests can point to their local models. Defaults to previous hardcoded path.
- `test_model_class_registry_includes_qwen3_asr` - Fix assertion for modified Class / package
- `test_optimum_rr_unit.py` - Fix logits for solution / document ordering