### PR TITLE
Add support for Qwen3-ASR segments in verbose and diarize responses

### DIFF
--- a/src/engine/openvino/qwen3_asr/qwen3_asr.py
+++ b/src/engine/openvino/qwen3_asr/qwen3_asr.py
@@ -21,7 +21,7 @@ import base64
 from pathlib import Path
 import logging
 import gc
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import openvino as ov
@@ -368,7 +368,7 @@ class OVQwen3ASR:
         )
         return raw, metrics
 
-    async def transcribe(self, gen_config: OV_Qwen3ASRGenConfig) -> AsyncIterator[Union[Dict[str, Any], str]]:
+    async def transcribe(self, gen_config: OV_Qwen3ASRGenConfig) -> Tuple[str, Dict[str, Any], List[Dict[str, Any]]]:
         t_transcribe_start = time.perf_counter()
         audio_input = gen_config.audio_base64
         assert audio_input, "audio_base64 is required"
@@ -382,9 +382,7 @@ class OVQwen3ASR:
 
         audio_seconds = len(audio_array) / SAMPLE_RATE
         if audio_seconds <= 0:
-            yield {}
-            yield ""
-            return
+            return "", {}, []
 
         max_chunk_sec = min(float(gen_config.max_chunk_sec), float(MAX_ASR_INPUT_SECONDS))
         chunk_items = await asyncio.to_thread(
@@ -399,6 +397,7 @@ class OVQwen3ASR:
 
         langs = []
         texts = []
+        segments = []
         agg = {
             "feature_sec": 0.0,
             "encoder_sec": 0.0,
@@ -422,6 +421,12 @@ class OVQwen3ASR:
             langs.append(lang)
             if text:
                 texts.append(text)
+                segments.append({
+                    "id": idx,
+                    "start": float(chunk_offset_sec),
+                    "end": float(chunk_offset_sec) + float(chunk_sec),
+                    "text": text,
+                })
             agg["feature_sec"] += chunk_metrics["feature_sec"]
             agg["encoder_sec"] += chunk_metrics["encoder_sec"]
             agg["prefill_sec"] += chunk_metrics["prefill_sec"]
@@ -453,8 +458,7 @@ class OVQwen3ASR:
         if merged_language:
             metrics["language"] = merged_language
 
-        yield metrics
-        yield text
+        return text, metrics, segments
 
     async def unload_model(self, registry: ModelRegistry, model_name: str) -> bool:
         removed = await registry.register_unload(model_name)

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -535,7 +535,7 @@ async def openai_audio_transcriptions(
             gen_config = OVGenAI_WhisperGenConfig(audio_base64=audio_base64)
             result = await _workers.transcribe_whisper(model, gen_config)
 
-        metrics = result.get("metrics", {})
+        metrics: Dict[str, Any] = result.get("metrics", {})
         logger.info(f"[audio/transcriptions] model={model} metrics={metrics}")
 
         if response_format == "json":
@@ -544,8 +544,16 @@ async def openai_audio_transcriptions(
             return {
                 "text": result.get("text", ""),
                 "language": metrics.get("language"),
-                "duration": metrics.get("duration"),
+                "duration": metrics.get("duration") or metrics.get("audio_duration_sec"),
+                "segments": result.get("segments", []),
                 "metrics": metrics,
+            }
+        elif response_format == "diarized_json":
+            return {
+                "duration": metrics.get("duration") or metrics.get("audio_duration_sec"),
+                "segments": result.get("segments", []),
+                "task": "transcribe",
+                "text": result.get("text", ""),
             }
         else:
             return result.get("text", "")

--- a/src/server/worker_registry.py
+++ b/src/server/worker_registry.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 import soundfile as sf
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from src.engine.ov_genai.llm import OVGenAI_LLM
 from src.engine.ov_genai.vlm import OVGenAI_VLM
@@ -66,6 +66,7 @@ class WorkerPacket:
     ]
     response: Optional[str] = None
     metrics: Optional[Dict[str, Any]] = None
+    segments: Optional[List[Dict[str, Any]]] = None
     # Orchestration plumbing
     result_future: Optional[asyncio.Future] = None
     stream_queue: Optional[asyncio.Queue] = None
@@ -191,21 +192,13 @@ class InferWorker:
     async def infer_qwen3_asr(packet: WorkerPacket, asr_model: OVQwen3ASR) -> WorkerPacket:
         """Transcribe audio for a single packet using the OVQwen3ASR pipeline."""
         metrics = None
-        final_text = ""
 
         try:
-            async for item in asr_model.transcribe(packet.gen_config):
-                if isinstance(item, dict):
-                    metrics = item
-                else:
-                    final_text = item
-
-            packet.response = final_text
-            packet.metrics = metrics
+            assert isinstance(packet.gen_config, OV_Qwen3ASRGenConfig), "Expected OV_Qwen3ASRGenConfig for Qwen3 ASR inference"
+            packet.response, packet.metrics, packet.segments = await asr_model.transcribe(packet.gen_config)
         except Exception as e:
             logger.error("Qwen3 ASR inference failed!", exc_info=True)
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
+            packet.response, packet.metrics, packet.segments = f"Error: {str(e)}", None, None
 
         return packet
 
@@ -899,7 +892,7 @@ class WorkerRegistry:
     async def transcribe_qwen3_asr(self, model_name: str, gen_config: OV_Qwen3ASRGenConfig) -> Dict[str, Any]:
         """Transcribe audio using Qwen3 ASR model."""
         request_id = uuid.uuid4().hex
-        result_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        result_future: asyncio.Future[WorkerPacket] = asyncio.get_running_loop().create_future()
         packet = WorkerPacket(
             request_id=request_id,
             id_model=model_name,
@@ -909,7 +902,14 @@ class WorkerRegistry:
         q = self._get_qwen3_asr_queue(model_name)
         await q.put(packet)
         completed = await result_future
-        return {"text": completed.response or "", "metrics": completed.metrics or {}}
+        
+        response: Dict[str, Any] = {"text": completed.response or ""}
+        if completed.metrics:
+            response["metrics"] = completed.metrics
+        if completed.segments:
+            response["segments"] = completed.segments
+        
+        return response
 
     async def generate_speech_qwen3_tts(self, model_name: str, gen_config: OV_Qwen3TTSGenConfig) -> Dict[str, Any]:
         """Generate speech using a loaded Qwen3 TTS model.

--- a/src/tests/test_openai_audio_transcriptions_unit.py
+++ b/src/tests/test_openai_audio_transcriptions_unit.py
@@ -1,0 +1,101 @@
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest  # type: ignore[import]
+
+import src.server.routes.openai as openai_module
+from src.server.models.registration import ModelType
+
+
+_AUDIO_BYTES = b"audio-bytes"
+_RESULT = {
+    "text": "hello world",
+    "metrics": {"language": "english", "audio_duration_sec": 4.0, "rtf": 0.5},
+    "segments": [{"id": 0, "start": 0.0, "end": 4.0, "text": "hello world"}],
+}
+
+
+class _FakeUpload:
+    async def read(self) -> bytes:
+        return _AUDIO_BYTES
+
+
+def _call(monkeypatch: pytest.MonkeyPatch, response_format: str, result=None, openarc_asr=None):
+    """Invoke the transcription handler with a loaded qwen3-asr model mocked in."""
+    result = _RESULT if result is None else result
+
+    fake_registry = SimpleNamespace(
+        _lock=asyncio.Lock(),
+        _models={
+            "qwen3": SimpleNamespace(model_name="qwen3-asr", model_type=ModelType.QWEN3_ASR),
+        },
+    )
+    transcribe_mock = AsyncMock(return_value=result)
+    fake_workers = SimpleNamespace(transcribe_qwen3_asr=transcribe_mock)
+
+    monkeypatch.setattr(openai_module, "_registry", fake_registry)
+    monkeypatch.setattr(openai_module, "_workers", fake_workers)
+
+    response = asyncio.run(
+        openai_module.openai_audio_transcriptions(
+            file=_FakeUpload(),
+            model="qwen3-asr",
+            response_format=response_format,
+            openarc_asr=openarc_asr,
+        )
+    )
+    return response, transcribe_mock
+
+
+def test_json_returns_text_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    response, _ = _call(monkeypatch, "json")
+    assert response == {"text": "hello world"}
+
+
+def test_verbose_json_includes_segments_and_duration(monkeypatch: pytest.MonkeyPatch) -> None:
+    response, _ = _call(monkeypatch, "verbose_json")
+    assert response == {
+        "text": "hello world",
+        "language": "english",
+        "duration": 4.0,  # falls back to audio_duration_sec (metrics has no "duration")
+        "segments": _RESULT["segments"],
+        "metrics": _RESULT["metrics"],
+    }
+
+
+def test_diarized_json_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    response, _ = _call(monkeypatch, "diarized_json")
+    assert response == {
+        "duration": 4.0,
+        "segments": _RESULT["segments"],
+        "task": "transcribe",
+        "text": "hello world",
+    }
+
+
+def test_duration_prefers_explicit_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = {
+        "text": "hi",
+        "metrics": {"duration": 9.9, "audio_duration_sec": 4.0},
+        "segments": [],
+    }
+    response, _ = _call(monkeypatch, "verbose_json", result=result)
+    assert response["duration"] == 9.9
+
+
+def test_missing_segments_defaults_to_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = {"text": "hi", "metrics": {"audio_duration_sec": 1.0}}  # no "segments" key
+    response, _ = _call(monkeypatch, "verbose_json", result=result)
+    assert response["segments"] == []
+
+
+def test_defaults_used_when_openarc_asr_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # openarc_asr is None -> handler builds a default qwen3 gen_config and still
+    # forwards the uploaded audio as base64.
+    _, transcribe_mock = _call(monkeypatch, "json", openarc_asr=None)
+
+    transcribe_mock.assert_awaited_once()
+    _model_arg, gen_config = transcribe_mock.await_args.args
+    assert gen_config.audio_base64 == base64.b64encode(_AUDIO_BYTES).decode("utf-8")

--- a/src/tests/test_qwen3_asr_unit.py
+++ b/src/tests/test_qwen3_asr_unit.py
@@ -1,5 +1,13 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import numpy as np
 import pytest  # type: ignore[import]
 
+import src.engine.openvino.qwen3_asr.qwen3_asr as qwen3_asr_module
+from src.engine.openvino.qwen3_asr.qwen3_asr import OVQwen3ASR, SAMPLE_RATE
+from src.server.models.openvino import OV_Qwen3ASRGenConfig
+from src.server.models.registration import EngineType, ModelLoadConfig, ModelType
 from src.engine.openvino.qwen3_asr.qwen3_asr_utils import (
     LANGUAGE_CODE_TO_NAME,
     SUPPORTED_LANGUAGES,
@@ -7,6 +15,133 @@ from src.engine.openvino.qwen3_asr.qwen3_asr_utils import (
     validate_language,
 )
 
+# audio_chunks returns (raw_output, chunk_metrics); collect_metrics sums these keys.
+_CHUNK_METRICS = {
+    "feature_sec": 1.0,
+    "encoder_sec": 1.0,
+    "prefill_sec": 1.0,
+    "decode_sec": 1.0,
+    "detok_sec": 1.0,
+    "prompt_tokens": 10,
+    "generated_tokens": 20,
+    "encoder_tokens": 5,
+}
+
+
+def _make_asr() -> OVQwen3ASR:
+    """Build an OVQwen3ASR without running __init__ (which reads model files)."""
+    asr = OVQwen3ASR.__new__(OVQwen3ASR)
+    asr.load_config = ModelLoadConfig(
+        model_path="unused",
+        model_name="test-qwen3-asr",
+        model_type=ModelType.QWEN3_ASR,
+        engine=EngineType.OPENVINO,
+        device="CPU",
+    )
+    asr.t_model_load = 0.0
+    return asr
+
+
+def _patch_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    audio_array: np.ndarray,
+    chunk_items: list,
+    parse_outputs: list,
+) -> OVQwen3ASR:
+    async def immediate_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(qwen3_asr_module.asyncio, "to_thread", immediate_to_thread)
+    monkeypatch.setattr(qwen3_asr_module, "normalize_audios", lambda _audio_input: [audio_array])
+    monkeypatch.setattr(
+        qwen3_asr_module,
+        "split_audio_into_chunks",
+        lambda **kwargs: chunk_items,
+    )
+    monkeypatch.setattr(
+        qwen3_asr_module,
+        "parse_asr_output",
+        MagicMock(side_effect=parse_outputs),
+    )
+    monkeypatch.setattr(qwen3_asr_module, "merge_languages", lambda _langs: "english")
+
+    asr = _make_asr()
+    asr.audio_chunks = MagicMock(return_value=("raw", dict(_CHUNK_METRICS)))
+    return asr
+
+
+def test_transcribe_returns_text_metrics_and_segments(monkeypatch: pytest.MonkeyPatch) -> None:
+    chunk_items = [
+        (np.zeros(int(SAMPLE_RATE * 1.5), dtype=np.float32), 0.0),
+        (np.zeros(int(SAMPLE_RATE * 2.0), dtype=np.float32), 1.5),
+    ]
+    asr = _patch_pipeline(
+        monkeypatch,
+        audio_array=np.zeros(SAMPLE_RATE * 4, dtype=np.float32),  # 4.0s
+        chunk_items=chunk_items,
+        parse_outputs=[("en", "hello "), ("en", "world")],
+    )
+
+    text, metrics, segments = asyncio.run(
+        asr.transcribe(OV_Qwen3ASRGenConfig(audio_base64="AAA"))
+    )
+
+    assert text == "hello world"
+    assert segments == [
+        {"id": 0, "start": 0.0, "end": 1.5, "text": "hello "},
+        {"id": 1, "start": 1.5, "end": 3.5, "text": "world"},
+    ]
+    # Metrics aggregate across the two chunks.
+    assert metrics["language"] == "english"
+    assert metrics["audio_duration_sec"] == 4.0
+    assert metrics["feature_sec"] == 2.0
+    assert metrics["prompt_tokens"] == 20
+    assert metrics["generated_tokens"] == 40
+    assert metrics["encoder_tokens"] == 10
+    # collect_metrics derives throughput from the summed values.
+    assert metrics["prefill_tok_s"] == 20 / 2.0
+    assert metrics["decode_tok_s"] == 40 / 2.0
+
+
+def test_transcribe_skips_empty_text_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Middle chunk yields no text -> no segment appended for it.
+    chunk_items = [
+        (np.zeros(int(SAMPLE_RATE * 1.0), dtype=np.float32), 0.0),
+        (np.zeros(int(SAMPLE_RATE * 1.0), dtype=np.float32), 1.0),
+        (np.zeros(int(SAMPLE_RATE * 1.0), dtype=np.float32), 2.0),
+    ]
+    asr = _patch_pipeline(
+        monkeypatch,
+        audio_array=np.zeros(SAMPLE_RATE * 3, dtype=np.float32),
+        chunk_items=chunk_items,
+        parse_outputs=[("en", "first"), ("en", ""), ("en", "third")],
+    )
+
+    text, _metrics, segments = asyncio.run(
+        asr.transcribe(OV_Qwen3ASRGenConfig(audio_base64="AAA"))
+    )
+
+    assert text == "firstthird"
+    assert len(segments) == 2
+    # NOTE: documents current behavior -- `id` is the chunk index, so skipping a
+    # middle chunk produces non-contiguous ids (0, 2) rather than OpenAI's
+    # contiguous segment indexing (0, 1).
+    assert [seg["id"] for seg in segments] == [0, 2]
+    assert [seg["text"] for seg in segments] == ["first", "third"]
+
+
+def test_transcribe_empty_audio_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    asr = _patch_pipeline(
+        monkeypatch,
+        audio_array=np.zeros(0, dtype=np.float32),  # 0s -> early return
+        chunk_items=[],
+        parse_outputs=[],
+    )
+
+    result = asyncio.run(asr.transcribe(OV_Qwen3ASRGenConfig(audio_base64="AAA")))
+
+    assert result == ("", {}, [])
 
 def test_resolve_language_name_maps_iso_639_1_code() -> None:
     assert resolve_language_name("en") == "English"

--- a/src/tests/test_worker_registry_integration.py
+++ b/src/tests/test_worker_registry_integration.py
@@ -11,7 +11,7 @@ from src.server.models.optimum import PreTrainedTokenizerConfig, RerankerConfig
 from src.server.models.ov_genai import OVGenAI_GenConfig, OVGenAI_WhisperGenConfig
 
 
-def _make_worker(response_value, metrics_value, supports_stream: bool = False):
+def _make_worker(response_value, metrics_value, supports_stream: bool = False, segments_value=None):
     async def _worker(model_name, model_queue, model_instance, registry):
         while True:
             packet = await model_queue.get()
@@ -24,6 +24,7 @@ def _make_worker(response_value, metrics_value, supports_stream: bool = False):
                 await packet.stream_queue.put(None)
             packet.response = response_value
             packet.metrics = metrics_value
+            packet.segments = segments_value
             if packet.result_future is not None and not packet.result_future.done():
                 packet.result_future.set_result(packet)
             model_queue.task_done()
@@ -249,6 +250,43 @@ def test_worker_registry_qwen3_asr_flow(worker_system) -> None:
 
     result = asyncio.run(_run())
     assert result == {"text": "qwen3-text", "metrics": {"chunks": 1}}
+
+
+def test_worker_registry_qwen3_asr_flow_with_segments(worker_system, monkeypatch: pytest.MonkeyPatch) -> None:
+    model_registry, worker_registry = worker_system
+
+    segments = [{"id": 0, "start": 0.0, "end": 2.0, "text": "hello world"}]
+    monkeypatch.setattr(
+        worker_module.QueueWorker,
+        "queue_worker_qwen3_asr",
+        _make_worker("hello world", {"chunks": 1}, segments_value=segments),
+    )
+
+    load_config = ModelLoadConfig(
+        model_path="/models/mock",
+        model_name="integration-qwen3-asr-segments",
+        model_type=ModelType.QWEN3_ASR,
+        engine=EngineType.OPENVINO,
+        device="CPU",
+        runtime_config={},
+    )
+
+    config = OV_Qwen3ASRGenConfig(audio_base64="AAA")
+
+    async def _run():
+        return await _load_do_unload(
+            model_registry,
+            worker_registry,
+            load_config,
+            worker_registry.transcribe_qwen3_asr("integration-qwen3-asr-segments", config),
+        )
+
+    result = asyncio.run(_run())
+    assert result == {
+        "text": "hello world",
+        "metrics": {"chunks": 1},
+        "segments": segments,
+    }
 
 
 def test_worker_registry_embed_flow(worker_system) -> None:

--- a/src/tests/test_worker_registry_unit.py
+++ b/src/tests/test_worker_registry_unit.py
@@ -10,7 +10,7 @@ from src.server.models.optimum import PreTrainedTokenizerConfig, RerankerConfig
 from src.server.models.ov_genai import OVGenAI_GenConfig, OVGenAI_WhisperGenConfig
 
 
-def _make_worker(response_value, metrics_value, supports_stream: bool = False):
+def _make_worker(response_value, metrics_value, supports_stream: bool = False, segments_value=None):
     async def _worker(model_name, model_queue, model_instance, registry):
         while True:
             packet = await model_queue.get()
@@ -23,6 +23,7 @@ def _make_worker(response_value, metrics_value, supports_stream: bool = False):
                 await packet.stream_queue.put(None)
             packet.response = response_value
             packet.metrics = metrics_value
+            packet.segments = segments_value
             if packet.result_future is not None and not packet.result_future.done():
                 packet.result_future.set_result(packet)
             model_queue.task_done()
@@ -217,6 +218,92 @@ def test_qwen3_asr_transcribe(worker_registry: worker_module.WorkerRegistry) -> 
 
     result = asyncio.run(_run())
     assert result == {"text": "qwen3-text", "metrics": {"chunks": 1}}
+
+
+def test_qwen3_asr_transcribe_includes_segments(
+    worker_registry: worker_module.WorkerRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    segments = [
+        {"id": 0, "start": 0.0, "end": 1.5, "text": "hello"},
+        {"id": 1, "start": 1.5, "end": 3.0, "text": "world"},
+    ]
+    monkeypatch.setattr(
+        worker_module.QueueWorker,
+        "queue_worker_qwen3_asr",
+        _make_worker("hello world", {"chunks": 2}, segments_value=segments),
+    )
+    record = _make_record(ModelType.QWEN3_ASR, "qwen3-asr-segments")
+    config = OV_Qwen3ASRGenConfig(audio_base64="AAA")
+
+    async def _run():
+        return await _load_and_call(worker_registry, record, worker_registry.transcribe_qwen3_asr("qwen3-asr-segments", config))
+
+    result = asyncio.run(_run())
+    assert result == {
+        "text": "hello world",
+        "metrics": {"chunks": 2},
+        "segments": segments,
+    }
+
+
+def test_qwen3_asr_transcribe_omits_empty_metrics_and_segments(
+    worker_registry: worker_module.WorkerRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Falsy metrics/segments must not appear as keys in the response.
+    monkeypatch.setattr(
+        worker_module.QueueWorker,
+        "queue_worker_qwen3_asr",
+        _make_worker("text only", {}, segments_value=[]),
+    )
+    record = _make_record(ModelType.QWEN3_ASR, "qwen3-asr-empty")
+    config = OV_Qwen3ASRGenConfig(audio_base64="AAA")
+
+    async def _run():
+        return await _load_and_call(worker_registry, record, worker_registry.transcribe_qwen3_asr("qwen3-asr-empty", config))
+
+    result = asyncio.run(_run())
+    assert result == {"text": "text only"}
+
+
+def test_infer_qwen3_asr_unpacks_tuple() -> None:
+    segments = [{"id": 0, "start": 0.0, "end": 1.0, "text": "hi"}]
+
+    class FakeASR:
+        async def transcribe(self, gen_config):
+            return "hi", {"chunks": 1}, segments
+
+    packet = worker_module.WorkerPacket(
+        request_id="r1",
+        id_model="qwen3-asr",
+        gen_config=OV_Qwen3ASRGenConfig(audio_base64="AAA"),
+    )
+
+    result = asyncio.run(worker_module.InferWorker.infer_qwen3_asr(packet, FakeASR()))
+
+    assert result is packet
+    assert packet.response == "hi"
+    assert packet.metrics == {"chunks": 1}
+    assert packet.segments == segments
+
+
+def test_infer_qwen3_asr_handles_error() -> None:
+    class FailingASR:
+        async def transcribe(self, gen_config):
+            raise RuntimeError("boom")
+
+    packet = worker_module.WorkerPacket(
+        request_id="r2",
+        id_model="qwen3-asr",
+        gen_config=OV_Qwen3ASRGenConfig(audio_base64="AAA"),
+    )
+
+    result = asyncio.run(worker_module.InferWorker.infer_qwen3_asr(packet, FailingASR()))
+
+    assert result is packet
+    assert packet.response.startswith("Error:")
+    assert "boom" in packet.response
+    assert packet.metrics is None
+    assert packet.segments is None
 
 
 def test_embed(worker_registry: worker_module.WorkerRegistry) -> None:


### PR DESCRIPTION
Added `segments` to response types `json_verbose` and `json_diarize`. This matches the OpenAI spec [here](https://developers.openai.com/api/reference/python/resources/audio#(resource)%20audio.transcriptions%20%3E%20(model)%20transcription_create_response%20%3E%20(schema)). This is extremely useful for subtitle alignment, as it allows chunking alignment along generated speech boundaries.