### PR TITLE
Fix: Don't use incomplete tokens

### DIFF
--- a/src/engine/ov_genai/streamers.py
+++ b/src/engine/ov_genai/streamers.py
@@ -44,6 +44,9 @@ class ChunkStreamer(StreamerBase):
             # Emit only the newly materialized portion
             if len(text) > self.last_print_len:
                 chunk = text[self.last_print_len:]
+                if chr(65533) in chunk:
+                    self.since_last_emit -= 1
+                    return openvino_genai.StreamingStatus.RUNNING
                 if chunk:
                     self.text_queue.put_nowait(chunk)
                 self.last_print_len = len(text)


### PR DESCRIPTION
Before:

<img width="1014" height="397" alt="image" src="https://github.com/user-attachments/assets/1dc66dfa-951e-4e59-b99e-4b54a78c756f" />


After:

<img width="1004" height="390" alt="image" src="https://github.com/user-attachments/assets/ffe58799-1acd-4d52-95b8-14f4103adfba" />
