### PR TITLE
docs: Updated Docker documentation and compose example for deployed images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,10 @@
-version: '3.8'
-
 services:
+
   openarc:
-    build:
-      context: .
-      target: ${BUILD_TARGET:-standard}
-      # Set env var "BUILD_TARGET" to "standard" or "battlemage" to build the standard or battlemage version.
-      # target: ${BUILD_TARGET:-battlemage}         # Switch to this to make battlemage version default
-    image: openarc:latest
+    image: ghcr.io/searchsavior/openarc:latest
+    # image: ghcr.io/searchsavior/openarc-battlemage:latest   <-- use this image for the battlemage version
     container_name: openarc
-    
+
     # GPU access
     devices:
       - /dev/dri:/dev/dri
@@ -36,7 +31,7 @@ services:
     # Restart policy
     restart: unless-stopped
     
-    # Logging
+    # Logging (optional)
     logging:
       driver: "json-file"
       options:

--- a/docs/install.md
+++ b/docs/install.md
@@ -88,40 +88,61 @@ Visit [OpenVINO System Requirments](https://docs.openvino.ai/2025/about-openvino
 === "Docker"
 
     Instead of fighting with Intel's own docker images, we built our own which is as close to boilerplate as possible. For a primer on docker [check out this video](https://www.youtube.com/watch?v=DQdB7wFEygo).
+    
+    Prebuilt Images are available on [ghcr.io](https://github.com/SearchSavior?tab=packages&repo_name=OpenArc).
 
+    **Running OpenArc with compose:**
 
-    **Build and run the container:**
+    download the `docker-compose.yaml` file from the repository (or clone the repository) and run:
     ```bash
-    docker-compose up --build -d
+    docker-compose up -d
     ```
-    _The above builds and runs the default image; to build and run the battlemage image, set an environment variable before building:_
-    ```bash
-    BUILD_TARGET=battlemage
-    docker-compose up --build -d
-    ```
+    > _To run the battlemage-optimized image, edit the `docker-compose.yaml` file and switch to the alternative `image:` entry._
 
-    **Run the container:**
-    ```bash
-    docker run -d -p 8000:8000 openarc:latest
-    ```
-    **Enter the container:**
-    ```bash
-    docker exec -it openarc /bin/bash
-    ```
+    **Optional Environment Variables for compose:**
 
-    Environment Variables
+    _(you can also place these environment variables in a `.env` file in the root of the repository)_
 
     ```bash
     export OPENARC_API_KEY="openarc-api-key" # optional — pass --use-api-key to openarc serve start to enforce
     export OPENARC_AUTOLOAD_MODEL="model_name" # model_name to load on startup
     export MODEL_PATH="/path/to/your/models" # mount your models to `/models` inside the container
-    docker-compose up --build -d
+    docker-compose up -d
     ```
+
+    **Run OpenArc with docker (no compose):**
+    ```
+    docker run --name openarc \
+        --device /dev/dri:/dev/dri \
+        -v <path-to-your-models-folder>:/models \
+        -v <path-to-config-folder>:/persist \
+        -p 8000:8000 \ 
+        ghcr.io/searchsavior/openarc:latest
+    ```
+    _(replace `openarc:latest` with `openarc-battlemage:latest` for the battlemage image)_ 
+
+    **Building the OpenArc docker images yourself**
+    
+    If you want to build the docker image yourself, clone the repository and build from the [Dockerfile](https://github.com/SearchSavior/OpenArc/blob/main/Dockerfile):
+
+    ```bash
+    docker build --target standard -t ghcr.io/searchsavior/openarc:latest .
+    ```
+    _or, for battlemage:_
+    ```bash
+    docker build --target battlemage -t ghcr.io/searchsavior/openarc-battlemage:latest .
+    ``` 
+
+    **Enter the container:**
+    ```bash
+    docker exec -it openarc /bin/bash
+    ```
+
+    
 
     Pass `--use-api-key` to `openarc serve start` to require clients to authenticate. See [serve](commands.md#serve) for details.
  
-
-    Take a look at the [Dockerfile](Dockerfile) and [docker-compose](docker-compose.yaml) for more details.
+    Take a look at the [Dockerfile](https://github.com/SearchSavior/OpenArc/blob/main/Dockerfile) and [docker-compose](https://github.com/SearchSavior/OpenArc/blob/main/docker-compose.yaml) for more details.
 
 
 


### PR DESCRIPTION
This updates the Docker Install docs to use the ghcr.io deployed OpenArc images.
Also updated the `docker-compose.yaml` file to pull the images from ghcr instead of forcing build.
Fixes #139 