### PR TITLE
Add Unit Test run as a GH Action / PR check

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,33 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          # Automatically installs the Python version specified in your pyproject.toml
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: |
+          uv sync --frozen
+          uv sync --group test --frozen
+
+      
+      - name: Run Unit Tests
+        # run unit tests, ignore / silence python warnings
+        run: uv run pytest -W ignore tests/unit
+


### PR DESCRIPTION
This should trigger to run on a PR to main or a Push to main. It can be enabled in a ruleset; either your existing branch protection ruleset or another one for checks, and can be set to be overridden or disabled.

FYI I won't be offended if you don't want this PR merged. I was really just sharpening my sword and thought this was a good target.

<img width="1313" height="850" alt="image" src="https://github.com/user-attachments/assets/89c89b4f-df32-40f7-8cc5-103b7553d1bc" />

...
... and, further down...
...

<img width="1298" height="646" alt="image" src="https://github.com/user-attachments/assets/86c43529-6c55-4a1f-8724-368b3e2f8bf9" />
