### PR TITLE
docs: note OpenVINO nightly requirement for Qwen3 MoE models on GPU

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -115,3 +115,21 @@ Qwen3.5 utilizes chat instructions for thinking control. You can enable thinking
 Previous reasoning is also retained within a conversation. You can enable or disable it similarily by adding `preserve_previous_think` to `chat_template_kwargs`.
 
 For example, to enable thinking and disable previous reasoning, you would pass `chat_template_kwargs` with a value of `{"enable_thinking": true, "preserve_previous_think": false}`.
+
+### Qwen3 MoE
+
+**GPU loading fails with "FuseMOE3GemmCompressed transformation did not match the routing subgraph"?**
+
+Qwen3 MoE models (e.g., `Qwen3-Coder-30B-A3B-Instruct`) require a recent OpenVINO build on GPU. Older builds fail during pipeline creation with:
+
+```
+[GPU] MOECompressed (GEMM3_SWIGLU) reached the GPU backend without being fused: FuseMOE3GemmCompressed transformation did not match the routing subgraph
+```
+
+This was a bug in the OpenVINO GPU plugin's MoE fusion pass and is fixed upstream in nightly `2026.4.0.dev20260730` and newer. Upgrade with:
+
+```
+uv pip install --pre -U openvino openvino-genai openvino-tokenizers --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+```
+
+After upgrading, clear the model cache directory (if one is configured) so the model recompiles, and restart the server if it was running before the upgrade.


### PR DESCRIPTION
Adds a `### Qwen3 MoE` subsection under "Model-Specific Instructions" in `docs/models.md` documenting:

- The GPU load failure signature (`FuseMOE3GemmCompressed transformation did not match the routing subgraph`) seen with Qwen3 MoE models (e.g., Qwen3-Coder-30B-A3B) on older OpenVINO builds
- The fix: upgrade to OpenVINO nightly `2026.4.0.dev20260730` or newer
- Clearing the model cache and restarting the server after upgrading

Verified locally: upgrading the nightly resolved the load failure for `qwen3-coder-30b-int4-ov` on `HETERO:GPU.1,GPU.0`.

Closes #154