### PR TITLE
fix: resolve result_future on inference error instead of tearing down the model

### DIFF
--- a/src/server/worker_registry.py
+++ b/src/server/worker_registry.py
@@ -97,13 +97,13 @@ def _commit_completed_packet(
 ) -> bool:
     """Complete the request future. Return True if the worker should exit."""
     if completed.error is not None:
-        logger.error(
-            f"[{model_name}] Inference failed, triggering model unload..."
-        )
+        # Resolve the caller and keep the worker/model alive; unloading here runs the
+        # pipeline destructor, which can touch a corrupted device context after certain
+        # errors and SIGABRT the whole process, taking every other loaded model with it.
+        logger.error(f"[{model_name}] Inference failed: {completed.error}")
         if packet.result_future is not None and not packet.result_future.done():
             packet.result_future.set_exception(completed.error)
-        asyncio.create_task(registry.register_unload(model_name))
-        return True
+        return False
     if packet.result_future is not None and not packet.result_future.done():
         packet.result_future.set_result(completed)
     return False

--- a/tests/unit/test_worker_registry_unit.py
+++ b/tests/unit/test_worker_registry_unit.py
@@ -310,7 +310,7 @@ def test_infer_qwen3_asr_handles_error() -> None:
     assert packet.segments is None
 
 
-def test_commit_treats_error_field_not_error_prefix() -> None:
+def test_commit_resolves_error_without_unloading_the_model() -> None:
     class DummyRegistry:
         def __init__(self):
             self.unloaded = []
@@ -342,11 +342,14 @@ def test_commit_treats_error_field_not_error_prefix() -> None:
             result_future=err_future,
             error=RuntimeError("gpu oom"),
         )
-        assert worker_module._commit_completed_packet(err, err, "m", registry) is True
+        # On error the worker resolves the caller's future and keeps the model loaded;
+        # unloading here runs the pipeline destructor, which can SIGABRT the process if
+        # the device context is corrupted (see queue_worker_llm docstring).
+        assert worker_module._commit_completed_packet(err, err, "m", registry) is False
         with pytest.raises(RuntimeError, match="gpu oom"):
             err_future.result()
         await asyncio.sleep(0)
-        assert registry.unloaded == ["m"]
+        assert registry.unloaded == []
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Root cause

`_commit_completed_packet` fires `registry.register_unload(model_name)` on every
inference error before returning True, which breaks every `queue_worker_*` loop
out of its `while True`. Unload runs the pipeline destructor, which can touch a
corrupted device context after a real GPU error and SIGABRT the whole process,
taking every other loaded model down with it.

This is the second half of #153. The first half (the HTTP caller hanging
forever because `result_future` was never resolved) is already fixed on main
by 204f543 (PR #158's `_mark_inference_error`/`_commit_completed_packet`
rework), which also unified all 8 workers through one function. That refactor
kept the unload-on-error call, so the SIGABRT risk this issue reports is still
live on current main.

## Fix

`_commit_completed_packet` now resolves the caller's future with the error and
returns `False` unconditionally, so the worker stays in its loop and the model
stays loaded, instead of unloading and exiting.

## Verification

- `test_commit_resolves_error_without_unloading_the_model` (renamed from
  `test_commit_treats_error_field_not_error_prefix`, same file) now asserts
  `_commit_completed_packet` returns `False` and `registry.unloaded == []` on
  an error packet. Confirmed **fails on unmodified main** (`AssertionError:
  assert True is False`, current behavior unloads) and **passes on this
  branch**, in a clean `python:3.12-slim` container.
- Full `uv run pytest -W ignore tests/unit`: 125 passed, no regressions.
- Not checked: the reported SIGABRT itself, same caveat as before, no real
  Intel GPU/OpenCL context available in this session. This removes the
  `register_unload` call on the error path entirely, but I can't reproduce
  the abort to confirm it's gone, only that the destructor is no longer
  called on that path.

Fixes #153
