### PR TITLE
Add Qwen XML tool-call parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 [dependency-groups]
 test = [
     "pytest>=8.4.2",
-    "pytest-asyncio>=1.4.0"
+    "pytest-asyncio>=1.4.0",
+    "httpx>=0.27",
 ]
 
 [build-system]

--- a/src/engine/openvino/kokoro.py
+++ b/src/engine/openvino/kokoro.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import AsyncIterator, NamedTuple
 
+import numpy as np
 import openvino as ov
 import soundfile as sf
 import torch
@@ -36,9 +37,17 @@ class OV_Kokoro(KModel):
     """
     
     def __init__(self, load_config: ModelLoadConfig):
-        super().__init__()
+        # Skip KModel.__init__: it downloads config.json + model.pth from HF.
+        torch.nn.Module.__init__(self)
         self.model = None
         self._device = None
+        self.vocab = {}
+        self.context_length = 0
+        self.repo_id = None
+
+    @property
+    def device(self):
+        return torch.device("cpu")
 
     def load_model(self, load_config: ModelLoadConfig):
         self.model_path = Path(load_config.model_path)
@@ -57,6 +66,33 @@ class OV_Kokoro(KModel):
             core.set_property(load_config.runtime_config)
         self.model = core.compile_model(self.model_path / "openvino_model.xml", self._device)
         return self.model
+
+    def forward_with_tokens(self, input_ids, ref_s, speed: float = 1):
+        """Run the compiled OpenVINO IR instead of the PyTorch KModel graph."""
+        if self.model is None:
+            raise RuntimeError("OpenVINO Kokoro model is not loaded")
+
+        feed = {}
+        for inp in self.model.inputs:
+            name = inp.get_any_name()
+            key = name.lower()
+            if "speed" in key:
+                feed[name] = np.array(speed, dtype=np.float32)
+            elif "input" in key or key.endswith("ids"):
+                feed[name] = input_ids.detach().cpu().numpy()
+            elif "ref" in key or "style" in key:
+                feed[name] = ref_s.detach().cpu().numpy()
+        if not feed:
+            feed = {
+                self.model.inputs[0].get_any_name(): input_ids.detach().cpu().numpy(),
+            }
+        result = self.model(feed)
+        tensors = list(result.values())
+        audio = torch.from_numpy(np.asarray(tensors[0])).squeeze()
+        pred_dur = None
+        if len(tensors) > 1:
+            pred_dur = torch.from_numpy(np.asarray(tensors[1]))
+        return audio, pred_dur
 
     async def unload_model(self, registry: ModelRegistry, model_name: str) -> bool:
         """Unregister model from registry and free memory resources.

--- a/src/engine/openvino/kokoro.py
+++ b/src/engine/openvino/kokoro.py
@@ -12,7 +12,6 @@ import re
 from pathlib import Path
 from typing import AsyncIterator, NamedTuple
 
-import numpy as np
 import openvino as ov
 import soundfile as sf
 import torch
@@ -37,17 +36,9 @@ class OV_Kokoro(KModel):
     """
     
     def __init__(self, load_config: ModelLoadConfig):
-        # Skip KModel.__init__: it downloads config.json + model.pth from HF.
-        torch.nn.Module.__init__(self)
+        super().__init__()
         self.model = None
         self._device = None
-        self.vocab = {}
-        self.context_length = 0
-        self.repo_id = None
-
-    @property
-    def device(self):
-        return torch.device("cpu")
 
     def load_model(self, load_config: ModelLoadConfig):
         self.model_path = Path(load_config.model_path)
@@ -66,33 +57,6 @@ class OV_Kokoro(KModel):
             core.set_property(load_config.runtime_config)
         self.model = core.compile_model(self.model_path / "openvino_model.xml", self._device)
         return self.model
-
-    def forward_with_tokens(self, input_ids, ref_s, speed: float = 1):
-        """Run the compiled OpenVINO IR instead of the PyTorch KModel graph."""
-        if self.model is None:
-            raise RuntimeError("OpenVINO Kokoro model is not loaded")
-
-        feed = {}
-        for inp in self.model.inputs:
-            name = inp.get_any_name()
-            key = name.lower()
-            if "speed" in key:
-                feed[name] = np.array(speed, dtype=np.float32)
-            elif "input" in key or key.endswith("ids"):
-                feed[name] = input_ids.detach().cpu().numpy()
-            elif "ref" in key or "style" in key:
-                feed[name] = ref_s.detach().cpu().numpy()
-        if not feed:
-            feed = {
-                self.model.inputs[0].get_any_name(): input_ids.detach().cpu().numpy(),
-            }
-        result = self.model(feed)
-        tensors = list(result.values())
-        audio = torch.from_numpy(np.asarray(tensors[0])).squeeze()
-        pred_dur = None
-        if len(tensors) > 1:
-            pred_dur = torch.from_numpy(np.asarray(tensors[1]))
-        return audio, pred_dur
 
     async def unload_model(self, registry: ModelRegistry, model_name: str) -> bool:
         """Unregister model from registry and free memory resources.

--- a/src/engine/ov_genai/qwen_tool_parser.py
+++ b/src/engine/ov_genai/qwen_tool_parser.py
@@ -1,0 +1,520 @@
+"""Qwen3.5 XML tool-call parser + streamer built directly on StreamerBase.
+
+Avoids TextParserStreamer/IncrementalParser entirely (a live VLMPipeline run
+with a Python TextParserStreamer subclass hung deterministically after tool
+call completion). Instead, ToolCallStreamer(StreamerBase) does its own
+incremental decode (cumulative decode + delta slicing, like OpenArc's
+ChunkStreamer) and feeds text deltas through:
+
+  ReasoningSplitter       - everything before </think> is reasoning_content
+                            (Qwen3.5 emits no opening <think> tag)
+  QwenXmlToolCallParser   - state machine for the Qwen XML tool format:
+
+    <tool_call>
+    <function=NAME>
+    <parameter=KEY>
+    VALUE
+    </parameter>
+    ...
+    </function>
+    </tool_call>
+
+Parallel calls are sequential <tool_call> blocks; text may precede the first
+block. The parser strips tool XML from content and emits OpenAI-style
+streaming fragments:
+
+    {"index": i, "id": ..., "type": "function",
+     "function": {"name": "", "arguments": ""}}          # call start
+    {"index": i, "function": {"name": NAME}}             # name known
+    {"index": i, "function": {"arguments": FRAGMENT}}    # argument deltas
+
+Concatenating all `arguments` fragments for an index yields complete JSON.
+Queued delta messages look like:
+    {"content": str} / {"reasoning_content": str} / {"tool_calls": [frag, ...]}
+None signals completion.
+"""
+import asyncio
+import itertools
+import json
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import openvino_genai
+from openvino_genai import StreamerBase, StreamingStatus
+
+TOOL_OPEN = "<tool_call>"
+TOOL_CLOSE = "</tool_call>"
+FUNC_OPEN = "<function="
+FUNC_CLOSE = "</function>"
+PARAM_OPEN = "<parameter="
+PARAM_CLOSE = "</parameter>"
+GT = ">"
+THINK_OPEN = "<think>"
+THINK_CLOSE = "</think>"
+
+# Tags we try to match by token ID (vLLM TokenIDScanner style). Only
+# single-token tags qualify; <function= etc. are multi-token ordinary text
+# and stay on the text-level hold-back path.
+WRAPPER_TAGS = (TOOL_OPEN, TOOL_CLOSE, THINK_OPEN, THINK_CLOSE)
+
+# States
+CONTENT = "content"
+IN_TOOL_CALL = "in_tool_call"
+IN_FUNC_NAME = "in_func_name"
+IN_FUNCTION = "in_function"
+IN_PARAM_NAME = "in_param_name"
+IN_PARAM = "in_param"
+AFTER_FUNCTION = "after_function"
+
+REPLACEMENT_CHAR = chr(65533)  # U+FFFD: decode produced a partial character
+
+
+def _holdback_suffix(text: str, tags) -> int:
+    """Length of the longest suffix of `text` that is a proper prefix of a tag.
+
+    Anything before that suffix is safe to process now; the suffix must wait
+    for more deltas (it could grow into a full tag).
+    """
+    max_hold = 0
+    upper = max(len(t) for t in tags) - 1
+    for n in range(1, min(len(text), upper) + 1):
+        suffix = text[-n:]
+        if any(t != suffix and t.startswith(suffix) for t in tags):
+            max_hold = n
+    return max_hold
+
+
+def _json_escape_fragment(s: str) -> str:
+    """Escape a raw string fragment for embedding inside a JSON string."""
+    out = []
+    for ch in s:
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ord(ch) < 0x20:
+            out.append(f"\\u{ord(ch):04x}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+class ReasoningSplitter:
+    """Splits the leading thinking block from regular content.
+
+    Qwen3.5 with enable_thinking=True emits reasoning immediately (no opening
+    tag) and terminates it with </think>. Everything before the close tag is
+    reasoning; everything after is content.
+    """
+
+    def __init__(self, close_tag: str = THINK_CLOSE, enabled: bool = True):
+        self._close_tag = close_tag
+        self._buf = ""
+        # Only treat the stream as reasoning when the prompt actually opened a
+        # <think> block (chat template appends '<think>\n' to the prompt when
+        # enable_thinking=True; with False it pre-closes an empty block and the
+        # stream is pure content).
+        self.in_reasoning = enabled
+
+    def feed(self, text: str) -> Tuple[str, str]:
+        """Returns (reasoning_delta, content_delta)."""
+        self._buf += text
+        reasoning_out, content_out = "", ""
+        while self._buf:
+            if not self.in_reasoning:
+                content_out += self._buf
+                self._buf = ""
+                break
+            idx = self._buf.find(self._close_tag)
+            if idx != -1:
+                reasoning_out += self._buf[:idx]
+                self._buf = self._buf[idx + len(self._close_tag):]
+                self.in_reasoning = False
+                continue
+            hold = _holdback_suffix(self._buf, (self._close_tag,))
+            reasoning_out += self._buf[: len(self._buf) - hold]
+            self._buf = self._buf[len(self._buf) - hold:]
+            break
+        return reasoning_out, content_out
+
+
+class QwenXmlToolCallParser:
+    """Incremental parser for Qwen XML tool calls.
+
+    `tools` is the OpenAI-style tools list from the request; used for argument
+    type coercion (booleans arrive Python-style: True/False).
+    """
+
+    def __init__(self, tools: Optional[List[Dict[str, Any]]] = None):
+        self._param_types: Dict[str, Dict[str, str]] = {}
+        for tool in tools or []:
+            fn = tool.get("function", {})
+            props = (fn.get("parameters") or {}).get("properties") or {}
+            self._param_types[fn.get("name", "")] = {
+                k: (v.get("type") or "string") for k, v in props.items()
+            }
+        self.reset()
+
+    def reset(self) -> None:
+        self._ids = itertools.count()
+        self._buf = ""
+        self._state = CONTENT
+        self._calls: List[Dict[str, Any]] = []
+        self._cur: Optional[Dict[str, Any]] = None   # current call under construction
+        self._param_name = ""
+        self._param_raw = ""                          # buffered value (non-string types)
+        self._param_index = 0                         # params seen in current call
+        self._value_started = False                   # first chunk of current value?
+        self._pending_newline = False                 # trailing \n hold-back in values
+        self.status = StreamingStatus.RUNNING
+        self.errors: List[str] = []
+
+    @property
+    def tool_calls(self) -> List[Dict[str, Any]]:
+        """All calls seen so far, in final OpenAI non-streaming shape."""
+        return list(self._calls)
+
+    def feed(self, delta_text: str) -> Tuple[str, List[Dict[str, Any]]]:
+        """Consume a text delta. Returns (content_text, tool_call_fragments)."""
+        if not delta_text:
+            return "", []
+        self._buf += delta_text
+
+        content_out: List[str] = []
+        fragments: List[Dict[str, Any]] = []
+
+        while self._buf:
+            if not self._step(content_out, fragments):
+                break  # need more input
+
+        return "".join(content_out), fragments
+
+    # -- state machine ----------------------------------------------------------
+
+    def _step(self, content_out: list, fragments: list) -> bool:
+        """Advance the machine once. False = wait for more input."""
+        buf = self._buf
+
+        if self._state == CONTENT:
+            idx = buf.find(TOOL_OPEN)
+            if idx == -1:
+                hold = _holdback_suffix(buf, (TOOL_OPEN,))
+                safe, self._buf = buf[: len(buf) - hold], buf[len(buf) - hold:]
+                if safe and not self._calls:
+                    content_out.append(safe)
+                elif safe and safe.strip():
+                    # After a completed call, real text means the model is
+                    # rambling past its answer -> stop generation.
+                    self.status = StreamingStatus.TOOL_CALL_STOP
+                # else: trailing whitespace after the final call -> drop
+                return False  # remaining buf is a partial tag prefix; wait
+            if idx > 0:
+                pre, self._buf = buf[:idx], buf[idx:]
+                if not self._calls:
+                    content_out.append(pre)
+                elif pre.strip():
+                    self.status = StreamingStatus.TOOL_CALL_STOP
+                return True
+            self._buf = buf[len(TOOL_OPEN):]
+            self._start_call(fragments)
+            self._state = IN_TOOL_CALL
+            return True
+
+        if self._state == IN_TOOL_CALL:
+            return self._expect_tag(buf, (FUNC_OPEN,), IN_FUNC_NAME)
+
+        if self._state == IN_FUNC_NAME:
+            gt = buf.find(GT)
+            if gt == -1:
+                if "<" in buf:  # names never contain '<'; bail on garbage
+                    self.errors.append(f"malformed function name: {buf!r}")
+                    self._state = CONTENT
+                    return True
+                return False
+            name = buf[:gt].strip()
+            self._buf = buf[gt + 1:]
+            self._cur["function"]["name"] = name
+            fragments.append({
+                "index": len(self._calls) - 1,
+                "function": {"name": name},
+            })
+            self._state = IN_FUNCTION
+            return True
+
+        if self._state == IN_FUNCTION:
+            stripped = buf.lstrip()
+            if stripped.startswith(PARAM_OPEN):
+                self._buf = stripped[len(PARAM_OPEN):]
+                self._state = IN_PARAM_NAME
+                return True
+            if stripped.startswith(FUNC_CLOSE):
+                self._buf = stripped[len(FUNC_CLOSE):]
+                self._close_call(fragments)
+                self._state = AFTER_FUNCTION
+                return True
+            if not stripped or any(
+                t.startswith(stripped) and t != stripped
+                for t in (PARAM_OPEN, FUNC_CLOSE)
+            ):
+                return False  # whitespace only, or partial tag
+            self.errors.append(f"unexpected text inside <function>: {stripped[:20]!r}")
+            self._buf = stripped[1:]
+            return True
+
+        if self._state == IN_PARAM_NAME:
+            gt = buf.find(GT)
+            if gt == -1:
+                if "<" in buf:
+                    self.errors.append(f"malformed parameter name: {buf!r}")
+                    self._state = IN_FUNCTION
+                    return True
+                return False
+            self._param_name = buf[:gt].strip()
+            self._buf = buf[gt + 1:]
+            self._param_raw = ""
+            self._value_started = False
+            self._pending_newline = False
+            self._state = IN_PARAM
+            # open the JSON member
+            ptype = self._param_type(self._cur["function"]["name"], self._param_name)
+            sep = "{" if self._param_index == 0 else ", "
+            self._param_index += 1
+            self._frag(fragments, f'{sep}{json.dumps(self._param_name)}: ')
+            if ptype == "string":
+                self._frag(fragments, '"')
+            return True
+
+        if self._state == IN_PARAM:
+            idx = buf.find(PARAM_CLOSE)
+            ptype = self._param_type(self._cur["function"]["name"], self._param_name)
+            if idx == -1:
+                hold = _holdback_suffix(buf, (PARAM_CLOSE,))
+                safe, self._buf = buf[: len(buf) - hold], buf[len(buf) - hold:]
+                if safe:
+                    self._consume_value(safe, fragments, ptype, final=False)
+                return False
+            value, self._buf = buf[:idx], buf[idx + len(PARAM_CLOSE):]
+            self._consume_value(value, fragments, ptype, final=True)
+            self._state = IN_FUNCTION
+            return True
+
+        if self._state == AFTER_FUNCTION:
+            return self._expect_tag(buf, (TOOL_CLOSE,), CONTENT)
+
+        return False
+
+    def _expect_tag(self, buf: str, tags, next_state: str) -> bool:
+        stripped = buf.lstrip()
+        for t in tags:
+            if stripped.startswith(t):
+                self._buf = stripped[len(t):]
+                self._state = next_state
+                return True
+        if not stripped or any(
+            t.startswith(stripped) and t != stripped for t in tags
+        ):
+            return False  # whitespace only, or partial tag
+        self.errors.append(f"expected {tags}, got {stripped[:20]!r}")
+        self._buf = stripped[1:]
+        return True
+
+    # -- call/fragment helpers ----------------------------------------------------
+
+    def _frag(self, fragments: list, arguments: str):
+        fragments.append({
+            "index": len(self._calls) - 1,
+            "function": {"arguments": arguments},
+        })
+        self._cur["function"]["arguments"] += arguments
+
+    def _start_call(self, fragments: list):
+        self._cur = {
+            "id": f"call_{next(self._ids):024x}",
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+        }
+        self._calls.append(self._cur)
+        self._param_index = 0
+        fragments.append({
+            "index": len(self._calls) - 1,
+            "id": self._cur["id"],
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+        })
+
+    def _close_call(self, fragments: list):
+        self._frag(fragments, "}" if self._param_index > 0 else "{}")
+        self._cur["done"] = True
+
+    def _param_type(self, func_name: str, param: str) -> str:
+        return self._param_types.get(func_name, {}).get(param, "string")
+
+    def _consume_value(self, text: str, fragments: list, ptype: str, final: bool):
+        # drop the single wrapper newline right after <parameter=k>
+        if not self._value_started and text.startswith("\n"):
+            text = text[1:]
+        if text:
+            self._value_started = True
+        if ptype == "string":
+            # hold back a trailing newline: it may be the wrapper before
+            # </parameter>; if more value text follows we flush it then.
+            if self._pending_newline:
+                text = "\n" + text
+                self._pending_newline = False
+            if text.endswith("\n"):
+                if final:
+                    text = text[:-1]
+                else:
+                    self._pending_newline = True
+                    text = text[:-1]
+            if text:
+                self._param_raw += text
+                self._frag(fragments, _json_escape_fragment(text))
+            if final:
+                self._frag(fragments, '"')
+        else:
+            # buffer short scalar values; coerce + emit once complete
+            self._param_raw += text
+            if final:
+                self._frag(fragments, self._coerce(self._param_raw, ptype))
+
+    def _coerce(self, raw: str, ptype: str) -> str:
+        """Serialize a raw XML parameter value as JSON text."""
+        v = raw.strip()
+        if ptype in ("integer", "number"):
+            return v  # model emits digits
+        if ptype == "boolean":
+            low = v.lower()
+            if low in ("true", "1", "yes"):
+                return "true"
+            if low in ("false", "0", "no"):
+                return "false"
+            return json.dumps(v)  # fallback: keep as string
+        if ptype in ("array", "object"):
+            try:
+                return json.dumps(json.loads(v))
+            except (json.JSONDecodeError, TypeError):
+                return json.dumps(v)
+        return json.dumps(raw.strip("\n"))
+
+    def finalize(self) -> None:
+        """Call at end of generation to surface truncated structures."""
+        if self._cur is not None and not self._cur.get("done"):
+            self.errors.append("generation ended with unterminated tool call")
+        if self._state != CONTENT:
+            self.errors.append(f"generation ended in state {self._state}")
+
+
+class ToolCallStreamer(StreamerBase):
+    """StreamerBase doing its own incremental decode + tool-call parsing.
+
+    Mirrors ChunkStreamer's contract: decoded/parsed delta messages are put on
+    `queue` from the generation thread; None signals completion. Return value
+    controls generation: TOOL_CALL_STOP when the model rambles past a closed
+    tool call, CANCEL after cancel().
+    """
+
+    def __init__(self, tokenizer, tools: Optional[list] = None,
+                 enable_thinking: bool = True):
+        super().__init__()
+        self.tokenizer = tokenizer
+        self.reasoning = ReasoningSplitter(enabled=enable_thinking)
+        self.tool_parser = QwenXmlToolCallParser(tools)
+        self.tokens_cache: List[int] = []
+        self.last_print_len = 0
+        self._wrapper_ids: Dict[int, str] = {}
+        for tag in WRAPPER_TAGS:
+            ids = tokenizer.encode(tag).input_ids.data.tolist()[0]
+            if len(ids) == 1:
+                self._wrapper_ids[ids[0]] = tag
+        self.queue: "asyncio.Queue[Optional[dict]]" = asyncio.Queue()
+        self._cancelled = asyncio.Event()
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None  # offline use: no loop, put_nowait directly
+
+    def _enqueue(self, msg) -> None:
+        # write()/end() run on the C++ generation thread; asyncio.Queue is not
+        # thread-safe, so hop through call_soon_threadsafe when a loop exists.
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self.queue.put_nowait, msg)
+        else:
+            self.queue.put_nowait(msg)
+
+    def _process_delta(self, delta: str) -> None:
+        reasoning, text = self.reasoning.feed(delta)
+        content, fragments = self.tool_parser.feed(text)
+        msg: Dict[str, Any] = {}
+        if reasoning:
+            msg["reasoning_content"] = reasoning
+        if content:
+            msg["content"] = content
+        if fragments:
+            msg["tool_calls"] = fragments
+        if msg:
+            self._enqueue(msg)
+
+    def _decode_available(self) -> None:
+        text = self.tokenizer.decode(self.tokens_cache)
+        if len(text) > self.last_print_len:
+            delta = text[self.last_print_len:]
+            if REPLACEMENT_CHAR in delta:
+                # partial UTF-8 at the boundary; wait for more tokens
+                return
+            self.last_print_len = len(text)
+            self._process_delta(delta)
+
+    def _flush_text(self) -> None:
+        """Decode and process everything left in the cache, then reset it.
+
+        Called before an atomically-detected wrapper token: the special token
+        is a hard boundary, so any held-back partial tag in the text parser
+        must resolve now (it can't be a prefix of a wrapper tag anymore).
+        """
+        if not self.tokens_cache:
+            return
+        text = self.tokenizer.decode(self.tokens_cache)
+        if len(text) > self.last_print_len:
+            self._process_delta(text[self.last_print_len:])
+        self.tokens_cache = []
+        self.last_print_len = 0
+
+    def write(self, token: Union[int, List[int]]) -> StreamingStatus:
+        if self._cancelled.is_set():
+            self._enqueue(None)
+            return StreamingStatus.CANCEL
+
+        ids = token if isinstance(token, list) else [token]
+        for tid in ids:
+            tag = self._wrapper_ids.get(int(tid))
+            if tag is not None:
+                self._flush_text()
+                if tag == THINK_OPEN:
+                    # Opening tag is baked into the prompt by the chat
+                    # template; a stray one in the stream is a no-op.
+                    continue
+                # Atomic delivery: hold-back in the text parser resolves
+                # immediately, so this can never straddle chunks.
+                self._process_delta(tag)
+            else:
+                self.tokens_cache.append(int(tid))
+                self._decode_available()
+
+        return self.tool_parser.status
+
+    def end(self) -> None:
+        self._flush_text()
+        self.tool_parser.finalize()
+        self._enqueue(None)
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()

--- a/src/engine/ov_genai/streamers.py
+++ b/src/engine/ov_genai/streamers.py
@@ -21,13 +21,23 @@ class ChunkStreamer(StreamerBase):
         self.since_last_emit: int = 0              # tokens collected since last emit
         self.last_print_len: int = 0               # length of decoded text we've already emitted
         self.text_queue: "asyncio.Queue[Optional[str]]" = asyncio.Queue()
-        self._cancelled = asyncio.Event()          # cancellation flag for thread-safe signaling
+        self._cancelled = asyncio.Event()
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
+
+    def _enqueue(self, msg: Optional[str]) -> None:
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self.text_queue.put_nowait, msg)
+        else:
+            self.text_queue.put_nowait(msg)
 
     def write(self, token: Union[int, List[int]]) -> openvino_genai.StreamingStatus:
         # Check for cancellation first
         if self._cancelled.is_set():
             # Signal completion to the queue so the consumer can exit
-            self.text_queue.put_nowait(None)
+            self._enqueue(None)
             return openvino_genai.StreamingStatus.CANCEL
 
         # Normalize input to a list of ints
@@ -48,7 +58,7 @@ class ChunkStreamer(StreamerBase):
                     self.since_last_emit -= 1
                     return openvino_genai.StreamingStatus.RUNNING
                 if chunk:
-                    self.text_queue.put_nowait(chunk)
+                    self._enqueue(chunk)
                 self.last_print_len = len(text)
             self.since_last_emit = 0
 
@@ -68,6 +78,5 @@ class ChunkStreamer(StreamerBase):
         if len(text) > self.last_print_len:
             chunk = text[self.last_print_len:]
             if chunk:
-                self.text_queue.put_nowait(chunk)
-        # Signal completion
-        self.text_queue.put_nowait(None)
+                self._enqueue(chunk)
+        self._enqueue(None)

--- a/src/engine/ov_genai/vlm.py
+++ b/src/engine/ov_genai/vlm.py
@@ -17,7 +17,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 
 from src.server.schemas.modeling.contract_ovgenai_llm_and_vlm import OVGenAI_GenConfig
-from src.server.utils.chat import flatten_message_content
+from src.server.utils.chat import flatten_message_content, flatten_messages
 from src.server.utils.resolve_vlm_type import is_qwen3_5_architecture, resolve_vlm_vision_token
 from src.server.model_registry import ModelRegistry
 from src.server.schemas.registration import ModelLoadConfig
@@ -112,6 +112,7 @@ class OVGenAI_VLM:
 
         # Step 2: Build the chat template prompt using cached tokenizer
         tokenizer = self.tokenizer
+        text_messages = flatten_messages(text_messages)
         tokenized_messages: str = tokenizer.apply_chat_template(
             text_messages,
             tokenize=False,

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -164,6 +164,68 @@ def parse_tool_calls(
     return tool_calls
 
 
+def _prepend_system_instruction(messages: Any, instruction: str) -> Any:
+    if not isinstance(messages, list):
+        return messages
+    messages = [dict(message) for message in messages]
+    if messages and messages[0].get("role") == "system":
+        content = messages[0].get("content") or ""
+        messages[0]["content"] = f"{content}\n\n{instruction}".strip()
+    else:
+        messages.insert(0, {"role": "system", "content": instruction})
+    return messages
+
+
+def _apply_tool_choice(
+    messages: Any,
+    tools: Optional[List[Dict[str, Any]]],
+    tool_choice: Optional[Any],
+    parallel_tool_calls: Optional[bool],
+) -> tuple[Any, Optional[List[Dict[str, Any]]]]:
+    """Translate OpenAI tool-choice controls into Qwen prompt constraints."""
+    if tool_choice == "none":
+        return messages, None
+
+    effective_tools = tools
+    instruction = ""
+
+    if tool_choice in (None, "auto"):
+        pass
+    elif tool_choice == "required":
+        if not tools:
+            raise ValueError("tool_choice='required' needs at least one tool")
+        instruction = (
+            "You must emit at least one tool call now. Do not answer in natural "
+            "language. Select the best available tool and infer reasonable arguments."
+        )
+    elif isinstance(tool_choice, dict):
+        function = tool_choice.get("function") or {}
+        name = function.get("name")
+        if tool_choice.get("type") != "function" or not name:
+            raise ValueError("Named tool_choice must specify type='function' and function.name")
+        effective_tools = [
+            tool for tool in tools or []
+            if (tool.get("function") or {}).get("name") == name
+        ]
+        if not effective_tools:
+            raise ValueError(f"tool_choice references unknown function '{name}'")
+        instruction = (
+            f"You must call the provided '{name}' tool now. Output exactly one tool "
+            "call and no natural-language answer. Infer reasonable arguments from "
+            "the user's request."
+        )
+    else:
+        raise ValueError("tool_choice must be 'auto', 'none', 'required', or a named function")
+
+    if parallel_tool_calls is False and effective_tools:
+        suffix = "Call at most one tool in your response."
+        instruction = f"{instruction} {suffix}".strip()
+
+    if instruction:
+        messages = _prepend_system_instruction(messages, instruction)
+    return messages, effective_tools
+
+
 # ---- endpoints ----
 
 @router.get("/models", dependencies=[Depends(verify_api_key)])
@@ -196,8 +258,18 @@ async def openai_chat_completions(
     try:
         logger.info(f'"{request.model}" request received')
 
+        messages, tools = _apply_tool_choice(
+            request.messages,
+            request.tools,
+            request.tool_choice,
+            request.parallel_tool_calls,
+        )
+        chat_template_kwargs = dict(request.chat_template_kwargs or {})
+        if request.tool_choice == "required" or isinstance(request.tool_choice, dict):
+            chat_template_kwargs.setdefault("enable_thinking", False)
+
         config_kwargs = {
-            "messages": request.messages,
+            "messages": messages,
             "temperature": request.temperature,
             "max_tokens": request.max_tokens,
             "top_p": request.top_p,
@@ -206,11 +278,11 @@ async def openai_chat_completions(
             "do_sample": request.do_sample,
             "num_return_sequences": request.num_return_sequences,
             "stream": request.stream,
-            "tools": request.tools,
+            "tools": tools,
             "seed": request.seed,
             "frequency_penalty": request.frequency_penalty,
             "presence_penalty": request.presence_penalty,
-            "chat_template_kwargs": request.chat_template_kwargs,
+            "chat_template_kwargs": chat_template_kwargs,
         }
         config_kwargs = {k: v for k, v in config_kwargs.items() if v is not None}
 
@@ -221,8 +293,8 @@ async def openai_chat_completions(
         request_id = f"ov-{uuid.uuid4().hex[:24]}"
 
         thinking_enabled = True
-        if request.chat_template_kwargs:
-            thinking_enabled = request.chat_template_kwargs.get(
+        if chat_template_kwargs:
+            thinking_enabled = chat_template_kwargs.get(
                 "enable_thinking", True
             )
 
@@ -233,7 +305,7 @@ async def openai_chat_completions(
                 tool_call_sent = False
                 cancel_request_id = None
                 reasoning = ReasoningSplitter(enabled=thinking_enabled)
-                tool_parser = QwenXmlToolCallParser(request.tools)
+                tool_parser = QwenXmlToolCallParser(tools)
                 accumulated_text = ""
 
                 def _chunk(delta: dict) -> bytes:
@@ -355,7 +427,7 @@ async def openai_chat_completions(
             total_tokens = metrics.get("total_token", prompt_tokens + completion_tokens)
 
             reasoning_text, content_text, tool_calls = parse_generation(
-                text, request.tools, thinking_enabled
+                text, tools, thinking_enabled
             )
             message = {"role": "assistant"}
             finish_reason = "stop"

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -31,6 +31,10 @@ from src.server.schemas.requests_openai import (
     OpenArcASRConfig,
     RerankRequest,
 )
+from src.engine.ov_genai.qwen_tool_parser import (
+    QwenXmlToolCallParser,
+    ReasoningSplitter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +57,6 @@ def _extract_hermes_tool_call_payloads(text: str) -> List[str]:
         payload_start = start + len(open_tag)
         end = text.find(close_tag, payload_start)
         if end < 0:
-            # hermes parsers accept an open tool call until EOS
             payload = text[payload_start:].strip()
             if payload:
                 payloads.append(payload)
@@ -77,9 +80,28 @@ def _format_tool_call_arguments(arguments: Any) -> str:
     return json.dumps(arguments)
 
 
-def parse_tool_calls(text: str) -> Optional[List[Dict[str, Any]]]:
+def _finalize_qwen_calls(parser: QwenXmlToolCallParser) -> List[Dict[str, Any]]:
     tool_calls: List[Dict[str, Any]] = []
+    for call in parser.tool_calls:
+        fn = call.get("function") or {}
+        name = fn.get("name") or ""
+        if not name:
+            continue
+        tool_calls.append(
+            {
+                "id": call.get("id") or f"call_{uuid.uuid4().hex[:24]}",
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": fn.get("arguments") or "{}",
+                },
+            }
+        )
+    return tool_calls
 
+
+def parse_hermes_tool_calls(text: str) -> Optional[List[Dict[str, Any]]]:
+    tool_calls: List[Dict[str, Any]] = []
     for payload in _extract_hermes_tool_call_payloads(text):
         try:
             data = json.loads(payload)
@@ -98,8 +120,48 @@ def parse_tool_calls(text: str) -> Optional[List[Dict[str, Any]]]:
                 )
         except json.JSONDecodeError:
             continue
-
     return tool_calls if tool_calls else None
+
+
+def parse_generation(
+    text: str,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    enable_thinking: bool = True,
+) -> tuple[str, str, Optional[List[Dict[str, Any]]]]:
+    """Split model output into (reasoning, content, tool_calls).
+
+    Prefers Qwen XML ``<function=...>`` tool calls; falls back to Hermes JSON
+    inside ``<tool_call>`` tags.
+    """
+    # Whole-string parse: only split reasoning when </think> is present.
+    # Otherwise Hermes / plain replies would be swallowed as thinking.
+    reasoning, remainder = ReasoningSplitter(enabled="</think>" in text).feed(text)
+    if remainder.startswith("<think>"):
+        remainder = remainder[len("<think>") :]
+
+    if "<function=" in remainder:
+        parser = QwenXmlToolCallParser(tools)
+        content, _ = parser.feed(remainder)
+        parser.finalize()
+        tool_calls = _finalize_qwen_calls(parser) or None
+        return reasoning, content, tool_calls
+
+    hermes = parse_hermes_tool_calls(remainder)
+    if hermes:
+        content = remainder
+        for payload in _extract_hermes_tool_call_payloads(remainder):
+            content = content.replace(f"<tool_call>{payload}</tool_call>", "")
+            content = content.replace(f"<tool_call>\n{payload}\n</tool_call>", "")
+        return reasoning, content.strip(), hermes
+
+    return reasoning, remainder, None
+
+
+def parse_tool_calls(
+    text: str, tools: Optional[List[Dict[str, Any]]] = None
+) -> Optional[List[Dict[str, Any]]]:
+    _, _, tool_calls = parse_generation(text, tools)
+    return tool_calls
 
 
 # ---- endpoints ----
@@ -158,14 +220,26 @@ async def openai_chat_completions(
         created_ts = int(time.time())
         request_id = f"ov-{uuid.uuid4().hex[:24]}"
 
+        thinking_enabled = True
+        if request.chat_template_kwargs:
+            thinking_enabled = request.chat_template_kwargs.get(
+                "enable_thinking", True
+            )
+
         if generation_config.stream:
 
             async def event_stream() -> AsyncIterator[bytes]:
-                accumulated_text = ""
                 metrics_data = None
                 tool_call_sent = False
-                tool_call_started = False
                 cancel_request_id = None
+                reasoning = ReasoningSplitter(enabled=thinking_enabled)
+                tool_parser = QwenXmlToolCallParser(request.tools)
+                accumulated_text = ""
+
+                def _chunk(delta: dict) -> bytes:
+                    return (
+                        f"data: {json.dumps({'id': request_id, 'object': 'chat.completion.chunk', 'created': created_ts, 'model': model_name, 'choices': [{'index': 0, 'delta': delta, 'finish_reason': None}]})}\n\n"
+                    ).encode()
 
                 try:
                     async for item in _workers.stream_generate(
@@ -187,83 +261,16 @@ async def openai_chat_completions(
                             continue
 
                         accumulated_text += item
-                        if not tool_call_started:
-                            tool_call_started = (
-                                "<tool_call>" in accumulated_text
-                                or "<tool_call" in accumulated_text
-                                or "<tool_" in accumulated_text
-                            )
+                        reason_delta, text_delta = reasoning.feed(item)
+                        content_delta, fragments = tool_parser.feed(text_delta)
 
-                        tool_calls = parse_tool_calls(accumulated_text)
-
-                        if tool_calls and not tool_call_sent:
+                        if reason_delta:
+                            yield _chunk({"reasoning_content": reason_delta})
+                        if content_delta:
+                            yield _chunk({"content": content_delta})
+                        if fragments:
                             tool_call_sent = True
-                            for idx, tc in enumerate(tool_calls):
-                                tool_call_start = {
-                                    "id": request_id,
-                                    "object": "chat.completion.chunk",
-                                    "created": created_ts,
-                                    "model": model_name,
-                                    "choices": [
-                                        {
-                                            "index": 0,
-                                            "delta": {
-                                                "tool_calls": [
-                                                    {
-                                                        "index": idx,
-                                                        "id": tc["id"],
-                                                        "type": tc["type"],
-                                                        "function": {
-                                                            "name": tc["function"]["name"],
-                                                            "arguments": "",
-                                                        },
-                                                    }
-                                                ]
-                                            },
-                                            "finish_reason": None,
-                                        }
-                                    ],
-                                }
-                                yield (f"data: {json.dumps(tool_call_start)}\n\n").encode()
-
-                                tool_call_args = {
-                                    "id": request_id,
-                                    "object": "chat.completion.chunk",
-                                    "created": created_ts,
-                                    "model": model_name,
-                                    "choices": [
-                                        {
-                                            "index": 0,
-                                            "delta": {
-                                                "tool_calls": [
-                                                    {
-                                                        "index": idx,
-                                                        "function": {
-                                                            "arguments": tc["function"]["arguments"]
-                                                        },
-                                                    }
-                                                ]
-                                            },
-                                            "finish_reason": None,
-                                        }
-                                    ],
-                                }
-                                yield (f"data: {json.dumps(tool_call_args)}\n\n").encode()
-                        elif not tool_calls and not tool_call_started:
-                            chunk_payload = {
-                                "id": request_id,
-                                "object": "chat.completion.chunk",
-                                "created": created_ts,
-                                "model": model_name,
-                                "choices": [
-                                    {
-                                        "index": 0,
-                                        "delta": {"content": item},
-                                        "finish_reason": None,
-                                    }
-                                ],
-                            }
-                            yield (f"data: {json.dumps(chunk_payload)}\n\n").encode()
+                            yield _chunk({"tool_calls": fragments})
                 except asyncio.CancelledError:
                     if cancel_request_id:
                         await _workers.infer_cancel(cancel_request_id)
@@ -271,6 +278,40 @@ async def openai_chat_completions(
                             f"[chat/completions] Task cancelled, cleaned up {cancel_request_id}"
                         )
                     raise
+
+                tool_parser.finalize()
+                if not tool_call_sent:
+                    hermes = parse_hermes_tool_calls(accumulated_text)
+                    if hermes:
+                        tool_call_sent = True
+                        for idx, tc in enumerate(hermes):
+                            yield _chunk(
+                                {
+                                    "tool_calls": [
+                                        {
+                                            "index": idx,
+                                            "id": tc["id"],
+                                            "type": tc["type"],
+                                            "function": {
+                                                "name": tc["function"]["name"],
+                                                "arguments": "",
+                                            },
+                                        }
+                                    ]
+                                }
+                            )
+                            yield _chunk(
+                                {
+                                    "tool_calls": [
+                                        {
+                                            "index": idx,
+                                            "function": {
+                                                "arguments": tc["function"]["arguments"]
+                                            },
+                                        }
+                                    ]
+                                }
+                            )
 
                 prompt_tokens = (metrics_data or {}).get("input_token", 0)
                 completion_tokens = (metrics_data or {}).get("new_token", 0)
@@ -311,16 +352,21 @@ async def openai_chat_completions(
             completion_tokens = metrics.get("new_token", 0)
             total_tokens = metrics.get("total_token", prompt_tokens + completion_tokens)
 
-            tool_calls = parse_tool_calls(text)
+            reasoning_text, content_text, tool_calls = parse_generation(
+                text, request.tools, thinking_enabled
+            )
             message = {"role": "assistant"}
             finish_reason = "stop"
 
+            if reasoning_text:
+                message["reasoning_content"] = reasoning_text
+
             if tool_calls:
-                message["content"] = None
+                message["content"] = content_text or None
                 message["tool_calls"] = tool_calls
                 finish_reason = "tool_calls"
             else:
-                message["content"] = text
+                message["content"] = content_text if content_text else text
 
             return {
                 "id": request_id,

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -257,6 +257,8 @@ async def openai_chat_completions(
                             return
 
                         if isinstance(item, dict):
+                            if item.get("error"):
+                                raise RuntimeError(item["error"])
                             metrics_data = item.get("metrics", item)
                             continue
 
@@ -442,6 +444,8 @@ async def openai_completions(request: OpenAICompletionRequest, raw_request: Requ
                             return
 
                         if isinstance(item, dict):
+                            if item.get("error"):
+                                raise RuntimeError(item["error"])
                             metrics_data = item.get("metrics", item)
                             continue
 

--- a/src/server/schemas/requests_openai.py
+++ b/src/server/schemas/requests_openai.py
@@ -30,6 +30,8 @@ class OpenAIChatCompletionRequest(BaseModel):
     model: str
     messages: Any
     tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    parallel_tool_calls: Optional[bool] = None
     stream: Optional[bool] = None
     
     temperature: Optional[float] = None
@@ -101,4 +103,3 @@ class RerankRequest(BaseModel):
     prefix: Optional[str] = None
     suffix: Optional[str] = None
     instruction: Optional[str] = None
-

--- a/src/server/utils/chat.py
+++ b/src/server/utils/chat.py
@@ -50,12 +50,44 @@ def flatten_message_content(content: Any) -> str:
     return "\n".join(fragment for fragment in _iter_text_fragments(content))
 
 
+def _arguments_as_mapping(arguments: Any) -> Any:
+    """Qwen chat templates iterate ``arguments|items`` and need a mapping."""
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            return arguments
+        return parsed if isinstance(parsed, dict) else arguments
+    return arguments
+
+
+def normalize_tool_calls_for_template(tool_calls: Any) -> Any:
+    if not isinstance(tool_calls, list):
+        return tool_calls
+    normalized: List[Dict[str, Any]] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            normalized.append(call)
+            continue
+        fn = call.get("function")
+        if isinstance(fn, dict) and "arguments" in fn:
+            fn = {**fn, "arguments": _arguments_as_mapping(fn.get("arguments"))}
+            normalized.append({**call, "function": fn})
+        else:
+            call = {**call, "arguments": _arguments_as_mapping(call.get("arguments"))}
+            normalized.append(call)
+    return normalized
+
+
 def flatten_messages(messages: List[Dict[str, Any]] | None) -> List[Dict[str, Any]]:
     if not messages:
         return []
 
-    return [
-        {**message, "content": flatten_message_content(message.get("content"))}
-        for message in messages
-    ]
+    out: List[Dict[str, Any]] = []
+    for message in messages:
+        item = {**message, "content": flatten_message_content(message.get("content"))}
+        if "tool_calls" in item:
+            item["tool_calls"] = normalize_tool_calls_for_template(item.get("tool_calls"))
+        out.append(item)
+    return out
 

--- a/src/server/worker_registry.py
+++ b/src/server/worker_registry.py
@@ -73,6 +73,40 @@ class WorkerPacket:
     # Orchestration plumbing
     result_future: Optional[asyncio.Future] = None
     stream_queue: Optional[asyncio.Queue] = None
+    error: Optional[BaseException] = None
+
+
+def _mark_inference_error(packet: WorkerPacket, exc: BaseException) -> None:
+    packet.error = exc
+    packet.response = None
+    packet.metrics = None
+
+
+async def _signal_stream_error(packet: WorkerPacket, exc: BaseException) -> None:
+    if packet.stream_queue is None:
+        return
+    await packet.stream_queue.put({"error": str(exc)})
+    await packet.stream_queue.put(None)
+
+
+def _commit_completed_packet(
+    packet: WorkerPacket,
+    completed: WorkerPacket,
+    model_name: str,
+    registry: ModelRegistry,
+) -> bool:
+    """Complete the request future. Return True if the worker should exit."""
+    if completed.error is not None:
+        logger.error(
+            f"[{model_name}] Inference failed, triggering model unload..."
+        )
+        if packet.result_future is not None and not packet.result_future.done():
+            packet.result_future.set_exception(completed.error)
+        asyncio.create_task(registry.register_unload(model_name))
+        return True
+    if packet.result_future is not None and not packet.result_future.done():
+        packet.result_future.set_result(completed)
+    return False
 
 class InferWorker:
     """
@@ -116,14 +150,10 @@ class InferWorker:
                     await packet.stream_queue.put({"metrics": metrics})
                 await packet.stream_queue.put(None)
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("LLM inference failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
-            # Signal error to stream if streaming
-            if packet.gen_config.stream and packet.stream_queue is not None:
-                await packet.stream_queue.put(None)
+            _mark_inference_error(packet, e)
+            if packet.gen_config.stream:
+                await _signal_stream_error(packet, e)
 
         return packet
 
@@ -152,14 +182,10 @@ class InferWorker:
                     await packet.stream_queue.put({"metrics": metrics})
                 await packet.stream_queue.put(None)
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("VLM inference failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
-            # Signal error to stream if streaming
-            if packet.gen_config.stream and packet.stream_queue is not None:
-                await packet.stream_queue.put(None)
+            _mark_inference_error(packet, e)
+            if packet.gen_config.stream:
+                await _signal_stream_error(packet, e)
 
         return packet
 
@@ -183,11 +209,8 @@ class InferWorker:
             packet.response = final_text
             packet.metrics = metrics
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("Whisper inference failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
+            _mark_inference_error(packet, e)
 
         return packet
 
@@ -201,7 +224,8 @@ class InferWorker:
             packet.response, packet.metrics, packet.segments = await asr_model.transcribe(packet.gen_config)
         except Exception as e:
             logger.error("Qwen3 ASR inference failed!", exc_info=True)
-            packet.response, packet.metrics, packet.segments = f"Error: {str(e)}", None, None
+            _mark_inference_error(packet, e)
+            packet.segments = None
 
         return packet
 
@@ -242,11 +266,8 @@ class InferWorker:
                 "total_samples": sum(len(chunk) for chunk in audio_chunks) if audio_chunks else 0
             }
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("Kokoro inference failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
+            _mark_inference_error(packet, e)
 
         return packet
 
@@ -271,8 +292,7 @@ class InferWorker:
             }
         except Exception as e:
             logger.error("Qwen3 TTS inference failed!", exc_info=True)
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
+            _mark_inference_error(packet, e)
 
         return packet
 
@@ -315,14 +335,10 @@ class InferWorker:
             packet.metrics = metrics
 
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("EMB inference failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
-            # Signal error to stream if streaming
-            if packet.gen_config.stream and packet.stream_queue is not None:
-                await packet.stream_queue.put(None)
+            _mark_inference_error(packet, e)
+            if getattr(packet.gen_config, "stream", False):
+                await _signal_stream_error(packet, e)
 
         return packet
 
@@ -343,14 +359,10 @@ class InferWorker:
             packet.metrics = metrics
 
         except Exception as e:
-            # Log the full exception with traceback
             logger.error("Reranking failed!", exc_info=True)
-            # Store error in packet response
-            packet.response = f"Error: {str(e)}"
-            packet.metrics = None
-            # Signal error to stream if streaming
-            if packet.gen_config.stream and packet.stream_queue is not None:
-                await packet.stream_queue.put(None)
+            _mark_inference_error(packet, e)
+            if getattr(packet.gen_config, "stream", False):
+                await _signal_stream_error(packet, e)
 
         return packet
 
@@ -372,17 +384,12 @@ class QueueWorker:
 
             completed_packet = await InferWorker.infer_llm(packet, llm_model)
 
-            # Check if inference failed and trigger model unload
-            if completed_packet.response and completed_packet.response.startswith("Error:"):
-                logger.error(f"[LLM Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
-
             if completed_packet.metrics:
                 logger.info(f"[LLM Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -398,17 +405,12 @@ class QueueWorker:
 
             completed_packet = await InferWorker.infer_vlm(packet, vlm_model)
 
-            # Check if inference failed and trigger model unload
-            if completed_packet.response and completed_packet.response.startswith("Error:"):
-                logger.error(f"[VLM Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
-
             if completed_packet.metrics:
                 logger.info(f"[VLM Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -424,17 +426,12 @@ class QueueWorker:
 
             completed_packet = await InferWorker.infer_whisper(packet, whisper_model)
 
-            # Check if inference failed and trigger model unload
-            if completed_packet.response and completed_packet.response.startswith("Error:"):
-                logger.error(f"[Whisper Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
-
             if completed_packet.metrics:
                 logger.info(f"[Whisper Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -450,16 +447,12 @@ class QueueWorker:
 
             completed_packet = await InferWorker.infer_qwen3_asr(packet, asr_model)
 
-            if completed_packet.response and completed_packet.response.startswith("Error:"):
-                logger.error(f"[Qwen3ASR Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
-
             if completed_packet.metrics:
                 logger.info(f"[Qwen3ASR Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -475,19 +468,12 @@ class QueueWorker:
 
             completed_packet = await InferWorker.infer_kokoro(packet, kokoro_model)
 
-            # Check if inference failed and trigger model unload
-            if completed_packet.response and completed_packet.response.startswith("Error:"):
-                logger.error(f"[Kokoro Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
-
-            # Log the text that was converted to speech
-
             if completed_packet.metrics:
                 logger.info(f"[Kokoro Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -505,16 +491,13 @@ class QueueWorker:
                 completed_packet = await InferWorker.infer_qwen3_tts_stream(packet, tts_model)
             else:
                 completed_packet = await InferWorker.infer_qwen3_tts(packet, tts_model)
-                if completed_packet.response and completed_packet.response.startswith("Error:"):
-                    logger.error(f"[Qwen3TTS Worker: {model_name}] Inference failed, triggering model unload...")
-                    asyncio.create_task(registry.register_unload(model_name))
-                    break
 
             if completed_packet.metrics:
                 logger.info(f"[Qwen3TTS Worker: {model_name}] Metrics: {completed_packet.metrics}")
 
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
 
             model_queue.task_done()
 
@@ -529,15 +512,11 @@ class QueueWorker:
                 break
 
             completed_packet = await InferWorker.infer_emb(packet, emb_model)
-            # Check if inference failed and trigger model unload
-            if not completed_packet.response:
-                logger.error(f"[EMB Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
             if completed_packet.metrics:
                 logger.info(f"[EMB Worker: {model_name}] Metrics: {completed_packet.metrics}")
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
             model_queue.task_done()
 
     @staticmethod
@@ -551,15 +530,11 @@ class QueueWorker:
                 break
 
             completed_packet = await InferWorker.infer_rerank(packet, rr_model)
-            # Check if inference failed and trigger model unload
-            if not completed_packet.response:
-                logger.error(f"[Reranker Worker: {model_name}] Inference failed, triggering model unload...")
-                asyncio.create_task(registry.register_unload(model_name))
-                break
             if completed_packet.metrics:
                 logger.info(f"[Reranker Worker: {model_name}] Metrics: {completed_packet.metrics}")
-            if packet.result_future is not None and not packet.result_future.done():
-                packet.result_future.set_result(completed_packet)
+            if _commit_completed_packet(packet, completed_packet, model_name, registry):
+                model_queue.task_done()
+                break
             model_queue.task_done()
 
 class WorkerRegistry:
@@ -845,8 +820,21 @@ class WorkerRegistry:
                 item = await stream_queue.get()
                 if item is None:
                     break
+                if isinstance(item, dict) and item.get("error"):
+                    raise RuntimeError(item["error"])
                 yield item
+            if result_future.done():
+                exc = result_future.exception()
+                if exc is not None:
+                    raise exc
+            else:
+                await result_future
         finally:
+            if not result_future.done():
+                result_future.cancel()
+            elif result_future.exception() is not None:
+                # Retrieve so the event loop does not log "never retrieved".
+                result_future.exception()
             # Unregister active request when done
             async with self._lock:
                 self._active_requests.pop(request_id, None)

--- a/tests/unit/test_tool_call_parser_unit.py
+++ b/tests/unit/test_tool_call_parser_unit.py
@@ -141,3 +141,186 @@ async def test_openai_chat_completions_streaming_hermes_tool_call(monkeypatch: p
     ) == {"query": "OpenArc"}
 
     assert json_payloads[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+QWEN_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit": {"type": "string"},
+                },
+                "required": ["location"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_reminder",
+            "description": "Set a reminder",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task": {"type": "string"},
+                    "days": {"type": "integer"},
+                    "urgent": {"type": "boolean"},
+                },
+                "required": ["task", "days"],
+            },
+        },
+    },
+]
+
+
+QWEN_SINGLE = (
+    "The user asked for weather.\n</think>\n\n"
+    "<tool_call>\n<function=get_weather>\n"
+    "<parameter=location>\nWarsaw\n</parameter>\n"
+    "<parameter=unit>\ncelsius\n</parameter>\n"
+    "</function>\n</tool_call>\n"
+)
+
+QWEN_PARALLEL = (
+    "Need two tools.\n</think>\n\n"
+    "<tool_call>\n<function=get_weather>\n"
+    "<parameter=location>\nWarsaw\n</parameter>\n"
+    "<parameter=unit>\ncelsius\n</parameter>\n"
+    "</function>\n</tool_call>\n"
+    "<tool_call>\n<function=set_reminder>\n"
+    "<parameter=task>\ncall mom\n</parameter>\n"
+    "<parameter=days>\n3\n</parameter>\n"
+    "<parameter=urgent>\nTrue\n</parameter>\n"
+    "</function>\n</tool_call>\n"
+)
+
+QWEN_TYPED = (
+    "Reminder time.\n</think>\n\n"
+    "<tool_call>\n<function=set_reminder>\n"
+    "<parameter=task>\nwater the plants\n</parameter>\n"
+    "<parameter=days>\n5\n</parameter>\n"
+    "<parameter=urgent>\nFalse\n</parameter>\n"
+    "</function>\n</tool_call>\n"
+)
+
+
+def test_parse_tool_calls_supports_qwen_xml() -> None:
+    tool_calls = openai_routes.parse_tool_calls(QWEN_SINGLE, QWEN_TOOLS)
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {
+        "location": "Warsaw",
+        "unit": "celsius",
+    }
+
+
+def test_parse_tool_calls_supports_qwen_xml_parallel_and_bools() -> None:
+    tool_calls = openai_routes.parse_tool_calls(QWEN_PARALLEL, QWEN_TOOLS)
+
+    assert tool_calls is not None
+    assert [c["function"]["name"] for c in tool_calls] == [
+        "get_weather",
+        "set_reminder",
+    ]
+    assert json.loads(tool_calls[1]["function"]["arguments"]) == {
+        "task": "call mom",
+        "days": 3,
+        "urgent": True,
+    }
+
+
+def test_parse_generation_strips_thinking_and_xml() -> None:
+    reasoning, content, tool_calls = openai_routes.parse_generation(
+        QWEN_SINGLE, QWEN_TOOLS
+    )
+
+    assert "weather" in reasoning
+    assert "<tool_call>" not in content
+    assert "<function=" not in content
+    assert tool_calls is not None
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+
+
+def test_parse_tool_calls_qwen_typed_params() -> None:
+    tool_calls = openai_routes.parse_tool_calls(QWEN_TYPED, QWEN_TOOLS)
+    args = json.loads(tool_calls[0]["function"]["arguments"])
+    assert args["days"] == 5
+    assert args["urgent"] is False
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completions_non_streaming_qwen_xml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Workers:
+        async def generate(self, model_name: str, generation_config: Any) -> Dict[str, Any]:
+            return {
+                "text": QWEN_SINGLE,
+                "metrics": {"input_token": 4, "new_token": 6, "total_token": 10},
+            }
+
+    monkeypatch.setattr(openai_routes, "_workers", _Workers())
+
+    request = OpenAIChatCompletionRequest(
+        model="demo-model",
+        messages=[{"role": "user", "content": "Weather in Warsaw?"}],
+        tools=QWEN_TOOLS,
+        stream=False,
+    )
+
+    response = await openai_routes.openai_chat_completions(request, _DummyRequest())
+    choice = response["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert "reasoning_content" in choice["message"]
+    assert choice["message"].get("content") in (None, "", "\n\n")
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completions_streaming_qwen_xml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Workers:
+        async def stream_generate(self, model_name: str, generation_config: Any) -> AsyncIterator[Any]:
+            text = QWEN_SINGLE
+            for i in range(0, len(text), 7):
+                yield text[i : i + 7]
+            yield {"metrics": {"input_token": 2, "new_token": 3, "total_token": 5}}
+
+        async def infer_cancel(self, request_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(openai_routes, "_workers", _Workers())
+
+    request = OpenAIChatCompletionRequest(
+        model="demo-model",
+        messages=[{"role": "user", "content": "Weather in Warsaw?"}],
+        tools=QWEN_TOOLS,
+        stream=True,
+    )
+
+    response = await openai_routes.openai_chat_completions(request, _DummyRequest())
+    chunks: List[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+
+    payloads = [json.loads(p) for p in _extract_sse_payloads(chunks) if p != "[DONE]"]
+    names = []
+    args = ""
+    for payload in payloads:
+        for frag in payload["choices"][0]["delta"].get("tool_calls") or []:
+            fn = frag.get("function") or {}
+            if fn.get("name"):
+                names.append(fn["name"])
+            if fn.get("arguments"):
+                args += fn["arguments"]
+    assert "get_weather" in names
+    assert json.loads(args) == {"location": "Warsaw", "unit": "celsius"}
+    assert payloads[-1]["choices"][0]["finish_reason"] == "tool_calls"

--- a/tests/unit/test_tool_call_parser_unit.py
+++ b/tests/unit/test_tool_call_parser_unit.py
@@ -303,6 +303,45 @@ def test_parse_tool_calls_qwen_typed_params() -> None:
     assert args["urgent"] is False
 
 
+def test_apply_tool_choice_none_hides_tools() -> None:
+    messages, tools = openai_routes._apply_tool_choice(
+        [{"role": "user", "content": "Weather?"}], QWEN_TOOLS, "none", None
+    )
+    assert messages == [{"role": "user", "content": "Weather?"}]
+    assert tools is None
+
+
+def test_apply_tool_choice_required_adds_instruction() -> None:
+    messages, tools = openai_routes._apply_tool_choice(
+        [{"role": "user", "content": "Hello"}], QWEN_TOOLS, "required", None
+    )
+    assert messages[0]["role"] == "system"
+    assert "must emit at least one tool call" in messages[0]["content"].lower()
+    assert tools == QWEN_TOOLS
+
+
+def test_apply_named_tool_choice_filters_tools() -> None:
+    messages, tools = openai_routes._apply_tool_choice(
+        [{"role": "system", "content": "Be terse"}, {"role": "user", "content": "Do it"}],
+        QWEN_TOOLS,
+        {"type": "function", "function": {"name": "set_reminder"}},
+        False,
+    )
+    assert [tool["function"]["name"] for tool in tools] == ["set_reminder"]
+    assert "set_reminder" in messages[0]["content"]
+    assert "at most one" in messages[0]["content"].lower()
+
+
+def test_apply_named_tool_choice_rejects_unknown_tool() -> None:
+    with pytest.raises(ValueError, match="unknown function"):
+        openai_routes._apply_tool_choice(
+            [{"role": "user", "content": "Do it"}],
+            QWEN_TOOLS,
+            {"type": "function", "function": {"name": "missing"}},
+            None,
+        )
+
+
 @pytest.mark.asyncio
 async def test_openai_chat_completions_non_streaming_qwen_xml(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_tool_call_parser_unit.py
+++ b/tests/unit/test_tool_call_parser_unit.py
@@ -6,6 +6,54 @@ from fastapi.responses import StreamingResponse
 
 import src.server.routes.openai as openai_routes
 from src.server.schemas.requests_openai import OpenAIChatCompletionRequest
+from src.server.utils.chat import flatten_messages, normalize_tool_calls_for_template
+
+
+def test_normalize_tool_call_arguments_json_string_to_mapping() -> None:
+    calls = normalize_tool_calls_for_template(
+        [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "Warsaw", "unit": "celsius"}',
+                },
+            }
+        ]
+    )
+    assert calls[0]["function"]["arguments"] == {
+        "location": "Warsaw",
+        "unit": "celsius",
+    }
+
+
+def test_flatten_messages_preserves_tool_role_and_parses_args() -> None:
+    msgs = flatten_messages(
+        [
+            {"role": "user", "content": "Weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Tokyo"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"temp": 22}'},
+        ]
+    )
+    assert msgs[1]["content"] == ""
+    assert msgs[1]["tool_calls"][0]["function"]["arguments"]["location"] == "Tokyo"
+    assert msgs[2]["content"] == '{"temp": 22}'
+    assert msgs[2]["tool_call_id"] == "call_1"
+
 
 
 class _DummyRequest:

--- a/tests/unit/test_worker_registry_unit.py
+++ b/tests/unit/test_worker_registry_unit.py
@@ -303,10 +303,77 @@ def test_infer_qwen3_asr_handles_error() -> None:
     result = asyncio.run(worker_module.InferWorker.infer_qwen3_asr(packet, FailingASR()))
 
     assert result is packet
-    assert packet.response.startswith("Error:")
-    assert "boom" in packet.response
+    assert packet.error is not None
+    assert "boom" in str(packet.error)
+    assert packet.response is None
     assert packet.metrics is None
     assert packet.segments is None
+
+
+def test_commit_treats_error_field_not_error_prefix() -> None:
+    class DummyRegistry:
+        def __init__(self):
+            self.unloaded = []
+
+        async def register_unload(self, name):
+            self.unloaded.append(name)
+            return True
+
+    async def _run():
+        registry = DummyRegistry()
+        ok_future = asyncio.get_running_loop().create_future()
+        ok = worker_module.WorkerPacket(
+            request_id="ok",
+            id_model="m",
+            gen_config=OVGenAI_GenConfig(messages=[{"role": "user", "content": "hi"}]),
+            result_future=ok_future,
+            response="Error: invalid input",
+        )
+        assert worker_module._commit_completed_packet(ok, ok, "m", registry) is False
+        assert ok_future.result().response == "Error: invalid input"
+        await asyncio.sleep(0)
+        assert registry.unloaded == []
+
+        err_future = asyncio.get_running_loop().create_future()
+        err = worker_module.WorkerPacket(
+            request_id="err",
+            id_model="m",
+            gen_config=OVGenAI_GenConfig(messages=[{"role": "user", "content": "hi"}]),
+            result_future=err_future,
+            error=RuntimeError("gpu oom"),
+        )
+        assert worker_module._commit_completed_packet(err, err, "m", registry) is True
+        with pytest.raises(RuntimeError, match="gpu oom"):
+            err_future.result()
+        await asyncio.sleep(0)
+        assert registry.unloaded == ["m"]
+
+    asyncio.run(_run())
+
+
+def test_infer_llm_stream_error_is_not_silent_success() -> None:
+    class FailingLLM:
+        async def generate_type(self, gen_config):
+            raise RuntimeError("decode failed")
+            yield  # make this an async generator
+
+    packet = worker_module.WorkerPacket(
+        request_id="s1",
+        id_model="llm",
+        gen_config=OVGenAI_GenConfig(
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        ),
+        stream_queue=asyncio.Queue(),
+    )
+
+    result = asyncio.run(worker_module.InferWorker.infer_llm(packet, FailingLLM()))
+    assert result.error is not None
+    assert result.response is None
+    first = asyncio.run(packet.stream_queue.get())
+    assert first == {"error": "decode failed"}
+    assert asyncio.run(packet.stream_queue.get()) is None
+
 
 
 def test_embed(worker_registry: worker_module.WorkerRegistry) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1858,6 +1858,7 @@ dependencies = [
 
 [package.dev-dependencies]
 test = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -1894,6 +1895,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
 ]
@@ -2527,10 +2529,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coretext", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/ab/1776ac62687cb3d81e59517ca55970f26efa5a96bbf3ebcea57afcdd6b06/pyobjc_framework_applicationservices-12.2.tar.gz", hash = "sha256:4f6c4027405f709872e5b098f3cd86961bdf262fb80679a548725a02171bb0cf", size = 109325, upload-time = "2026-05-30T12:30:18.7Z" }
 wheels = [
@@ -2548,7 +2550,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/cc/927169225e72bab9c9b44285656768fb75052a0bc85fdbca62740e1ca43c/pyobjc_framework_cocoa-12.2.tar.gz", hash = "sha256:20b392e2b7241caad0538dfde12143343e5dfe48f72e7df660a7548e635903dc", size = 3125555, upload-time = "2026-05-30T12:35:09.273Z" }
 wheels = [
@@ -2566,9 +2568,9 @@ name = "pyobjc-framework-coretext"
 version = "12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/b0/e7ef99240f853d4dddde82c9c0114cc525de7355661b2bf2d5e04cfb1582/pyobjc_framework_coretext-12.2.tar.gz", hash = "sha256:82def2c281347e0677866315675124c84c36e9bc21651d62870cfdcecb7da34e", size = 97343, upload-time = "2026-05-30T12:37:00.996Z" }
 wheels = [
@@ -2586,8 +2588,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/a3/5ae4c90c13999b46315f549694f25c374c48a9f7ab18f98ace6e74f4a5c1/pyobjc_framework_quartz-12.2.tar.gz", hash = "sha256:b343395d4790323b0376fe20c83ac468510ba19f65429323ca211708c939d107", size = 3215525, upload-time = "2026-05-30T12:44:27.759Z" }
 wheels = [
@@ -3481,8 +3483,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts" },
+    { name = "standard-chunk" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -3503,7 +3505,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
@@ -3688,13 +3690,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", upload-time = "2026-05-12T16:20:12Z" },
@@ -3713,13 +3715,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:b9d0e8eed0af9321ffb12b75f4aca371b071254f12cf75875d5a8e7cc8f52b51", upload-time = "2026-05-12T23:16:33Z" },
@@ -3755,9 +3757,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", upload-time = "2026-05-12T16:20:37Z" },
@@ -3776,9 +3778,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1b06f42d48b62098114923d8a3fe9fa864182715db06584a515155db0aa8eb30", upload-time = "2026-05-12T16:20:36Z" },


### PR DESCRIPTION
## Summary
- Parse Qwen3.5/3.8 XML tool calls (`<function=...><parameter=...>`) on `/v1/chat/completions` instead of dropping them as non-Hermes JSON.
- Split `</think>` reasoning from content, support parallel calls and typed params (bool/int), and keep Hermes `<tool_call>{json}</tool_call>` as a fallback.
- Enqueue `ChunkStreamer` deltas via the event loop so generation-thread `put_nowait` is safe.

## Test plan
- [x] `pytest tests/unit/test_tool_call_parser_unit.py` — 11 passed (Hermes + Qwen XML, stream and non-stream)
- [x] Live `qwen3.8-27b` on OpenArc: `get_weather(location=Warsaw, unit=celsius)` returned `finish_reason=tool_calls` with valid JSON args
- [ ] Reviewer: `openarc load <qwen-vlm> &&` POST `/v1/chat/completions` with `tools` and confirm `message.tool_calls`