### PR TITLE
Don't assume hybrid-thinking by default in streaming chat completions

### DIFF
--- a/src/engine/ov_genai/qwen_tool_parser.py
+++ b/src/engine/ov_genai/qwen_tool_parser.py
@@ -221,7 +221,7 @@ class QwenXmlToolCallParser:
                     self.status = StreamingStatus.TOOL_CALL_STOP
                 return True
             self._buf = buf[len(TOOL_OPEN):]
-            self._start_call(fragments)
+            self._start_call()
             self._state = IN_TOOL_CALL
             return True
 
@@ -238,11 +238,7 @@ class QwenXmlToolCallParser:
                 return False
             name = buf[:gt].strip()
             self._buf = buf[gt + 1:]
-            self._cur["function"]["name"] = name
-            fragments.append({
-                "index": len(self._calls) - 1,
-                "function": {"name": name},
-            })
+            self._register_call(name, fragments)
             self._state = IN_FUNCTION
             return True
 
@@ -332,19 +328,28 @@ class QwenXmlToolCallParser:
         })
         self._cur["function"]["arguments"] += arguments
 
-    def _start_call(self, fragments: list):
+    def _start_call(self):
+        # Pending only: not registered in `_calls` (and no fragment emitted)
+        # until `_register_call` confirms this is really Qwen's
+        # <function=NAME> syntax. A <tool_call> block using a different
+        # format (e.g. Hermes-style raw JSON) never registers, so it can't
+        # surface as a bogus half-empty tool call - it's left for the
+        # accumulated-text Hermes fallback in openai.py to pick up instead.
         self._cur = {
             "id": f"call_{next(self._ids):024x}",
             "type": "function",
             "function": {"name": "", "arguments": ""},
         }
-        self._calls.append(self._cur)
         self._param_index = 0
+
+    def _register_call(self, name: str, fragments: list):
+        self._cur["function"]["name"] = name
+        self._calls.append(self._cur)
         fragments.append({
             "index": len(self._calls) - 1,
             "id": self._cur["id"],
             "type": "function",
-            "function": {"name": "", "arguments": ""},
+            "function": {"name": name, "arguments": ""},
         })
 
     def _close_call(self, fragments: list):

--- a/src/server/routes/openai.py
+++ b/src/server/routes/openai.py
@@ -292,11 +292,10 @@ async def openai_chat_completions(
         created_ts = int(time.time())
         request_id = f"ov-{uuid.uuid4().hex[:24]}"
 
-        thinking_enabled = True
-        if chat_template_kwargs:
-            thinking_enabled = chat_template_kwargs.get(
-                "enable_thinking", True
-            )
+        # Don't assume hybrid-thinking mode unless told to expect it (see PR
+        # description): models without a closing </think> tag would otherwise
+        # have their entire streamed answer misclassified as reasoning_content.
+        thinking_enabled = bool(chat_template_kwargs.get("enable_thinking", False))
 
         if generation_config.stream:
 


### PR DESCRIPTION
## Problem

Using Cline (VS Code) against a Qwen3-Coder model loaded on OpenArc, tool-calling
tasks fail with:

> Invalid API Response: The provider returned an empty or unparsable response.

...even though Cline's own "thinking" panel shows a complete, sensible answer
(including its `<attempt_completion>` XML). The real `content`/`tool_calls`
field the client actually reads from comes back empty.

### Root cause

`openai_chat_completions`'s streaming path decided whether to treat the model's
output as hybrid-thinking (`<think>...</think>`) using:

```python
thinking_enabled = True
if chat_template_kwargs:
    thinking_enabled = chat_template_kwargs.get("enable_thinking", True)
```

Since virtually no client (Cline included) ever sends `chat_template_kwargs`,
this defaulted to `True` on every request. That flag controls
`ReasoningSplitter`, which starts assuming the stream is inside a `<think>`
block and holds text back as `reasoning_content` until it sees a closing
`</think>`.

Qwen3-Coder (and other non-hybrid-thinking chat models) never emits that
closing tag at all. So the splitter never leaves reasoning mode: **every**
token of the real answer - plain text and tool calls alike - streams out as
`reasoning_content` for the whole response, while `content`/`tool_calls` stay
permanently empty. That's exactly what a client sees as "empty response," while
still rendering the (correctly generated) text in its reasoning/thinking UI.

The non-streaming path doesn't have this bug - it checks the *completed* text
for `"</think>" in text` before deciding whether to split reasoning out, so it
can never misjudge a model that doesn't use the tag. Streaming has to decide
up front, before generation starts, so it must not guess reasoning-mode by
default - only enable it when the request actually asks for it.

### Fix 1 - `src/server/routes/openai.py`

Default `thinking_enabled` to `False` unless `chat_template_kwargs.enable_thinking`
is explicitly set.

### Fix 2 - `src/engine/ov_genai/qwen_tool_parser.py`

Flipping that default surfaced a second, previously-masked bug. A Hermes-style
tool call (`<tool_call>{"name":...}</tool_call>`, raw JSON instead of Qwen's own
`<function=NAME>` XML) used to get silently absorbed as `reasoning_content`
before ever reaching `QwenXmlToolCallParser` - a separate end-of-stream fallback
that regexes the raw accumulated text for Hermes calls was quietly doing all the
work, and the existing streaming test for it only passed because of this masking.

With reasoning no longer swallowing that text, it now reaches
`QwenXmlToolCallParser` live. That parser only understands Qwen's own
`<function=NAME>` XML; fed raw JSON, it errored character-by-character but still
emitted one bogus, half-empty tool-call-start fragment the instant it saw
`<tool_call>`. That lone fragment flips `tool_call_sent = True` in the route,
which then skips the fallback that used to rescue this case - turning a clean
two-delta Hermes tool call into one garbage delta.

Fixed by not registering a call (or emitting its start fragment) the instant
`<tool_call>` appears - only once `<function=NAME>` is actually confirmed. A
`<tool_call>` block in some other format now never registers, so it can't
surface as a bogus fragment; it's left for the accumulated-text Hermes fallback
to handle, same as before.

## Testing

`uv run --group test python -m pytest tests/unit` - 125 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)